### PR TITLE
Single channel listener

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tags
 site
 rails.conf
 cabal-helper*
+.dir-locals.el

--- a/README.md
+++ b/README.md
@@ -89,9 +89,3 @@ SELECT pg_notify(
 ```
 
 Where `postgres-websockets-listener` is the database channel used by your instance of postgres-websockets and `chat` is the channel where the browser is connected (the same issued in the JWT used to connect).
-
-## Monitoring messages
-
-There is a way to receive a copy of every message sent from websocket clients to the server. This is useful in cases where one needs to audit the messages or persist then using an independent asynchronous process. To do so, one should enable a configuration called `audit-channel`. This option should be the name of a channel where all the messages sent from a websocket client will be replicated as an aditional NOTIFY command.
-
-When running the example page, all messages received by the audit channel are visible in the last section of the page.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,10 @@ For more options on notification processing check the [PostgREST documentation o
 
 To send a message to a particular channel on the browser one should notify the postgres-websockets listener channel and pass a JSON object containing the channel and payload such as:
 ```sql
-SELECT pg_notify('postgres-websockets-listener', json_build_object('channel', 'chat', 'payload', 'test')::text);
+SELECT pg_notify(
+  'postgres-websockets-listener',
+  json_build_object('channel', 'chat', 'payload', 'test')::text
+);
 ```
 
 Where `postgres-websockets-listener` is the database channel used by your instance of postgres-websockets and `chat` is the channel where the browser is connected (the same issued in the JWT used to connect).

--- a/README.md
+++ b/README.md
@@ -60,6 +60,33 @@ ws://eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtb2RlIjoicnciLCJjaGFubmVsIjoiY2hhdC
 
 To use a secure socket (`wss://`) you will need a proxy server like nginx to handle the TLS layer. Some services (e.g. Heroku) will handle this automatially.
 
+## Receiving messages from the browser
+
+Every message received from the browser will be in JSON format as:
+```javascript
+{
+  "claims": { "message_delivered_at": 0.0, "a_custom_claim_from_the_jwt": "your_custom_value" },
+  "channel": "destination_channel",
+  "payload": "message content"
+}
+```
+
+Where `claims` contain any custom claims added to the JWT with the added `message_delivered_at` which marks the timestamp in unix format of when the message was processed by postgres-websockets just before being sent to the database.
+Also `channel` contains the channel requested in the JWT, and this should be used to send any messages back to that particular client.
+Finally `payload` contain a string with the message contents.
+
+A easy way to process messages received asynchronously is to use [pg-recorder](https://github.com/diogob/pg-recorder) with some custom stored procedures.
+For more options on notification processing check the [PostgREST documentation on the topic](https://postgrest.com/en/v4.3/intro.html#external-notification).
+
+## Sending messages to the browser
+
+To send a message to a particular channel on the browser one should notify the postgres-websockets listener channel and pass a JSON object containing the channel and payload such as:
+```sql
+SELECT pg_notify('postgres-websockets-listener', json_build_object('channel', 'chat', 'payload', 'test')::text);
+```
+
+Where `postgres-websockets-listener` is the database channel used by your instance of postgres-websockets and `chat` is the channel where the browser is connected (the same issued in the JWT used to connect).
+
 ## Monitoring messages
 
 There is a way to receive a copy of every message sent from websocket clients to the server. This is useful in cases where one needs to audit the messages or persist then using an independent asynchronous process. To do so, one should enable a configuration called `audit-channel`. This option should be the name of a channel where all the messages sent from a websocket client will be replicated as an aditional NOTIFY command.

--- a/app/Config.hs
+++ b/app/Config.hs
@@ -41,7 +41,7 @@ data AppConfig = AppConfig {
   , configPath              :: Text
   , configHost              :: Text
   , configPort              :: Int
-  , configAuditChannel      :: Maybe Text
+  , configListenChannel     :: Text
   , configJwtSecret         :: ByteString
   , configJwtSecretIsBase64 :: Bool
   , configPool              :: Int
@@ -70,11 +70,14 @@ readOptions = do
     cHost     <- C.lookupDefault "*4" conf "server-host"
     cPort     <- C.lookupDefault 3000 conf "server-port"
     cAuditC   <- C.lookup conf "audit-channel"
+    cChannel  <- case cAuditC of
+      Just c -> C.lookupDefault c conf "listen-channel"
+      Nothing -> C.require conf "listen-channel"
     -- jwt ---------------
     cJwtSec   <- C.require conf "jwt-secret"
     cJwtB64   <- C.lookupDefault False conf "secret-is-base64"
 
-    return $ AppConfig cDbUri cPath cHost cPort cAuditC (encodeUtf8 cJwtSec) cJwtB64 cPool
+    return $ AppConfig cDbUri cPath cHost cPort cChannel (encodeUtf8 cJwtSec) cJwtB64 cPool
 
  where
   opts = info (helper <*> pathParser) $
@@ -107,6 +110,7 @@ readOptions = do
         |server-root = "./client-example"
         |server-host = "*4"
         |server-port = 3000
+        |listen-channel = 3000
         |
         |## choose a secret to enable JWT auth
         |## (use "@filename" to load from separate file)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -43,6 +43,7 @@ main = do
   conf <- loadSecretFile =<< readOptions
   let host = configHost conf
       port = configPort conf
+      listenChannel = toS $ configListenChannel conf
       pgSettings = toS (configDatabase conf)
       appSettings = setHost ((fromString . toS) host)
                   . setPort port
@@ -53,7 +54,7 @@ main = do
   putStrLn $ ("Listening on port " :: Text) <> show (configPort conf)
 
   pool <- P.acquire (configPool conf, 10, pgSettings)
-  multi <- newHasqlBroadcaster pgSettings
+  multi <- newHasqlBroadcaster listenChannel pgSettings
 
   runSettings appSettings $
     postgresWsMiddleware (configJwtSecret conf) pool multi $

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -57,7 +57,7 @@ main = do
   multi <- newHasqlBroadcaster listenChannel pgSettings
 
   runSettings appSettings $
-    postgresWsMiddleware (configJwtSecret conf) pool multi $
+    postgresWsMiddleware listenChannel (configJwtSecret conf) pool multi $
     logStdout $ staticApp $ defaultFileServerSettings $ toS $ configPath conf
 
 loadSecretFile :: AppConfig -> IO AppConfig

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -56,7 +56,7 @@ main = do
   multi <- newHasqlBroadcaster pgSettings
 
   runSettings appSettings $
-    postgresWsMiddleware (toS <$> configAuditChannel conf) (configJwtSecret conf) pool multi $
+    postgresWsMiddleware (configJwtSecret conf) pool multi $
     logStdout $ staticApp $ defaultFileServerSettings $ toS $ configPath conf
 
 loadSecretFile :: AppConfig -> IO AppConfig

--- a/client-example/client.js
+++ b/client-example/client.js
@@ -65,13 +65,9 @@ function jwt() {
 
 $(document).ready(function () {
     var ws = null;
-    var auditWs = null;
 
     $('#channel').keyup(updateJWT);
     updateJWT();
-
-    auditWs = createWebSocket('/audit/' + jwt());
-    auditWs.onmessage = onMessage('#audit-messages');
 
     $('#message-form').submit(function () {
         var text = $('#text').val();

--- a/client-example/index.html
+++ b/client-example/index.html
@@ -34,9 +34,6 @@
                 <h2>Messages sent to chat channel</h2>
                 <div id="messages">
                 </div>
-                <h2>Messages sent to audit channel</h2>
-                <div id="audit-messages">
-                </div>
             </div>
         </div>
     </body>

--- a/sample.conf
+++ b/sample.conf
@@ -8,7 +8,7 @@ db-pool = 10
 server-root = "./client-example"
 
 ## Sends a copy of every message received from websocket clients to the channel specified bellow as an aditional NOTIFY command.
-listen-channel = "audit"
+listen-channel = "postgres-websockets-listener"
 
 ## Host and port on which the websockets server (and the static files server) will be listening.
 server-host = "*4"

--- a/sample.conf
+++ b/sample.conf
@@ -8,7 +8,7 @@ db-pool = 10
 server-root = "./client-example"
 
 ## Sends a copy of every message received from websocket clients to the channel specified bellow as an aditional NOTIFY command.
-audit-channel = "audit"
+listen-channel = "audit"
 
 ## Host and port on which the websockets server (and the static files server) will be listening.
 server-host = "*4"

--- a/src/PostgresWebsockets.hs
+++ b/src/PostgresWebsockets.hs
@@ -99,7 +99,8 @@ notifySession claimsToSend ch wsCon send =
     jsonMsg :: M.HashMap Text A.Value -> ByteString -> ByteString
     jsonMsg cl = BL.toStrict . A.encode . Message cl ch . decodeUtf8With T.lenientDecode
 
+    claimsWithChannel = M.insert "channel" (A.String ch) claimsToSend
     claimsWithTime :: IO (M.HashMap Text A.Value)
     claimsWithTime = do
       time <- getPOSIXTime
-      return $ M.insert "message_delivered_at" (A.Number $ fromRational $ toRational time) claimsToSend
+      return $ M.insert "message_delivered_at" (A.Number $ fromRational $ toRational time) claimsWithChannel

--- a/src/PostgresWebsockets.hs
+++ b/src/PostgresWebsockets.hs
@@ -31,24 +31,25 @@ import           PostgresWebsockets.HasqlBroadcast     (newHasqlBroadcaster,
 
 data Message = Message
   { claims  :: A.Object
+  , channel :: Text
   , payload :: Text
   } deriving (Show, Eq, Generic)
 
 instance A.ToJSON Message
 
 -- | Given a secret, a function to fetch the system time, a Hasql Pool and a Multiplexer this will give you a WAI middleware.
-postgresWsMiddleware :: Maybe ByteString -> ByteString -> H.Pool -> Multiplexer -> Wai.Application -> Wai.Application
+postgresWsMiddleware :: ByteString -> H.Pool -> Multiplexer -> Wai.Application -> Wai.Application
 postgresWsMiddleware =
   WS.websocketsOr WS.defaultConnectionOptions `compose` wsApp
   where
-    compose = (.) . (.) . (.) . (.)
+    compose = (.) . (.) . (.)
 
 -- private functions
 
 -- when the websocket is closed a ConnectionClosed Exception is triggered
 -- this kills all children and frees resources for us
-wsApp :: Maybe ByteString -> ByteString -> H.Pool -> Multiplexer -> WS.ServerApp
-wsApp mAuditChannel secret pool multi pendingConn =
+wsApp :: ByteString -> H.Pool -> Multiplexer -> WS.ServerApp
+wsApp secret pool multi pendingConn =
   validateClaims requestChannel secret (toS jwtToken) >>= either rejectRequest forkSessions
   where
     hasRead m = m == ("r" :: ByteString) || m == ("rw" :: ByteString)
@@ -56,14 +57,13 @@ wsApp mAuditChannel secret pool multi pendingConn =
     rejectRequest = WS.rejectRequest pendingConn . encodeUtf8
     -- the URI has one of the two formats - /:jwt or /:channel/:jwt 
     pathElements = BS.split '/' $ BS.drop 1 $ WS.requestPath $ WS.pendingRequest pendingConn
-    jwtToken 
+    jwtToken
       | length pathElements > 1 = headDef "" $ tailSafe pathElements
       | length pathElements <= 1 = headDef "" pathElements
     requestChannel
       | length pathElements > 1 = Just $ headDef "" pathElements
       | length pathElements <= 1 = Nothing
-    notifySessionWithTime = notifySession
-    forkSessions (channel, mode, validClaims) = do
+    forkSessions (ch, mode, validClaims) = do
           -- role claim defaults to anon if not specified in jwt
           -- We should accept only after verifying JWT
           conn <- WS.acceptRequest pendingConn
@@ -71,15 +71,11 @@ wsApp mAuditChannel secret pool multi pendingConn =
           WS.forkPingThread conn 30
 
           when (hasRead mode) $
-            onMessage multi channel $ WS.sendTextData conn . B.payload
+            onMessage multi ch $ WS.sendTextData conn . B.payload
 
           when (hasWrite mode) $
-            let sendNotifications = void . case mAuditChannel of
-                                            Nothing -> notifyPool pool channel
-                                            Just auditChannel -> \mesg ->
-                                              notifyPool pool channel mesg >>
-                                              notifyPool pool auditChannel mesg
-            in notifySessionWithTime validClaims conn sendNotifications
+            let sendNotifications = void . notifyPool pool ch
+            in notifySession validClaims (toS ch) conn sendNotifications
 
           waitForever <- newEmptyMVar
           void $ takeMVar waitForever
@@ -88,10 +84,11 @@ wsApp mAuditChannel secret pool multi pendingConn =
 -- But it allows the function to ignore the claims structure and the source
 -- of the channel, so all claims decoding can be coded in the caller
 notifySession :: A.Object
+              -> Text
               -> WS.Connection
               -> (ByteString -> IO ())
               -> IO ()
-notifySession claimsToSend wsCon send =
+notifySession claimsToSend ch wsCon send =
   withAsync (forever relayData) wait
   where
     relayData = jsonMsgWithTime >>= send
@@ -100,7 +97,7 @@ notifySession claimsToSend wsCon send =
 
     -- we need to decode the bytestring to re-encode valid JSON for the notification
     jsonMsg :: M.HashMap Text A.Value -> ByteString -> ByteString
-    jsonMsg cl = BL.toStrict . A.encode . Message cl . decodeUtf8With T.lenientDecode
+    jsonMsg cl = BL.toStrict . A.encode . Message cl ch . decodeUtf8With T.lenientDecode
 
     claimsWithTime :: IO (M.HashMap Text A.Value)
     claimsWithTime = do

--- a/src/PostgresWebsockets/Broadcast.hs
+++ b/src/PostgresWebsockets/Broadcast.hs
@@ -12,8 +12,6 @@ module PostgresWebsockets.Broadcast ( Multiplexer (src)
                              , onMessage
                              , relayMessages
                              , relayMessagesForever
-                             , openChannelProducer
-                             , closeChannelProducer
                              -- * Re-exports
                              , readTQueue
                              , writeTQueue
@@ -34,7 +32,6 @@ data Message = Message { channel :: ByteString
 
 data Multiplexer = Multiplexer { channels :: M.Map ByteString Channel
                                , src :: ThreadId
-                               , commands :: TQueue SourceCommands
                                , messages :: TQueue Message
                                }
 
@@ -43,16 +40,7 @@ instance Show Multiplexer where
 
 data Channel = Channel { broadcast :: TChan Message
                        , listeners :: Integer
-                       , close :: STM ()
                        }
-
--- | Open a multiplexer's channel
-openChannelProducer :: Multiplexer -> ByteString -> STM ()
-openChannelProducer multi ch = writeTQueue (commands multi) (Open ch)
-
--- | Close a multiplexer's channel
-closeChannelProducer ::  Multiplexer -> ByteString -> STM ()
-closeChannelProducer multi chan = writeTQueue (commands multi) (Close chan)
 
 -- | Opens a thread that relays messages from the producer thread to the channels forever
 relayMessagesForever :: Multiplexer -> IO ThreadId
@@ -68,24 +56,21 @@ relayMessages multi =
       Nothing -> return ()
       Just c -> writeTChan (broadcast c) m
 
-newMultiplexer :: (TQueue SourceCommands -> TQueue Message -> IO a)
+newMultiplexer :: (TQueue Message -> IO a)
                -> (Either SomeException a -> IO ())
                -> IO Multiplexer
 newMultiplexer openProducer closeProducer = do
-  cmds <- newTQueueIO
   msgs <- newTQueueIO
-  m <- liftA2 Multiplexer M.newIO (forkFinally (openProducer cmds msgs) closeProducer)
-  return $ m cmds msgs
+  m <- liftA2 Multiplexer M.newIO (forkFinally (openProducer msgs) closeProducer)
+  return $ m msgs
 
 openChannel ::  Multiplexer -> ByteString -> STM Channel
 openChannel multi chan = do
     c <- newBroadcastTChan
     let newChannel = Channel{ broadcast = c
                             , listeners = 0
-                            , close = closeChannelProducer multi chan
                             }
     M.insert newChannel chan (channels multi)
-    openChannelProducer multi chan
     return newChannel
 
 {- |  Adds a listener to a certain multiplexer's channel.
@@ -103,15 +88,14 @@ onMessage multi chan action = do
       mC <- M.lookup chan (channels multi)
       let c = fromMaybe (panic $ "trying to remove listener from non existing channel: " <> toS chan) mC
       M.delete chan (channels multi)
-      if listeners c - 1 > 0
-        then M.insert Channel{ broadcast = broadcast c, listeners = listeners c - 1, close = close c} chan (channels multi)
-        else closeChannelProducer multi chan
+      when (listeners c - 1 > 0) $
+        M.insert Channel{ broadcast = broadcast c, listeners = listeners c - 1 } chan (channels multi)
     openChannelWhenNotFound =
       M.lookup chan (channels multi) >>= \case
                                             Nothing -> openChannel multi chan
                                             Just ch -> return ch
     addListener ch = do
       M.delete chan (channels multi)
-      let newChannel = Channel{ broadcast = broadcast ch, listeners = listeners ch + 1, close = close ch}
+      let newChannel = Channel{ broadcast = broadcast ch, listeners = listeners ch + 1}
       M.insert newChannel chan (channels multi)
       dupTChan $ broadcast newChannel

--- a/src/PostgresWebsockets/Broadcast.hs
+++ b/src/PostgresWebsockets/Broadcast.hs
@@ -7,7 +7,6 @@
 -}
 module PostgresWebsockets.Broadcast ( Multiplexer (src)
                              , Message (..)
-                             , SourceCommands (..)
                              , newMultiplexer
                              , onMessage
                              , relayMessages
@@ -25,10 +24,9 @@ import Control.Concurrent.STM.TQueue
 
 import GHC.Show
 
-data SourceCommands = Open ByteString | Close ByteString deriving (Show)
 data Message = Message { channel :: ByteString
-               , payload :: ByteString
-               } deriving (Eq, Show)
+                       , payload :: ByteString
+                       } deriving (Eq, Show)
 
 data Multiplexer = Multiplexer { channels :: M.Map ByteString Channel
                                , src :: ThreadId

--- a/src/PostgresWebsockets/Database.hs
+++ b/src/PostgresWebsockets/Database.hs
@@ -82,7 +82,7 @@ unlisten con channel =
 
 waitForNotifications :: (ByteString -> ByteString -> IO()) -> Connection -> IO ()
 waitForNotifications sendNotification con =
-  withLibPQConnection con $ void . forkIO . forever . pqFetch
+  withLibPQConnection con $ void . forever . pqFetch
   where
     pqFetch pqCon = do
       mNotification <- PQ.notifies pqCon

--- a/src/PostgresWebsockets/HasqlBroadcast.hs
+++ b/src/PostgresWebsockets/HasqlBroadcast.hs
@@ -26,15 +26,19 @@ import PostgresWebsockets.Broadcast
 {- | Returns a multiplexer from a connection URI, keeps trying to connect in case there is any error.
    This function also spawns a thread that keeps relaying the messages from the database to the multiplexer's listeners
 -}
-newHasqlBroadcaster :: ByteString -> IO Multiplexer
-newHasqlBroadcaster = newHasqlBroadcasterForConnection . tryUntilConnected
+newHasqlBroadcaster :: ByteString -> ByteString -> IO Multiplexer
+newHasqlBroadcaster ch = newHasqlBroadcasterForConnection . tryUntilConnected
+  where
+    newHasqlBroadcasterForConnection = newHasqlBroadcasterForChannel ch
 
 {- | Returns a multiplexer from a connection URI or an error message on the left case
    This function also spawns a thread that keeps relaying the messages from the database to the multiplexer's listeners
 -}
-newHasqlBroadcasterOrError :: ByteString -> IO (Either ByteString Multiplexer)
-newHasqlBroadcasterOrError =
+newHasqlBroadcasterOrError :: ByteString -> ByteString -> IO (Either ByteString Multiplexer)
+newHasqlBroadcasterOrError ch =
   acquire >=> (sequence . mapBoth show (newHasqlBroadcasterForConnection . return))
+  where
+    newHasqlBroadcasterForConnection = newHasqlBroadcasterForChannel ch
 
 tryUntilConnected :: ByteString -> IO Connection
 tryUntilConnected =
@@ -52,7 +56,7 @@ tryUntilConnected =
           return True
         _ -> return False
 
-{- | Returns a multiplexer from an IO Connection, listen for different database notification channels using the connection produced.
+{- | Returns a multiplexer from a channel and an IO Connection, listen for different database notifications on the provided channel using the connection produced.
 
    This function also spawns a thread that keeps relaying the messages from the database to the multiplexer's listeners
 
@@ -74,9 +78,6 @@ tryUntilConnected =
    @
 
 -}
-newHasqlBroadcasterForConnection :: IO Connection -> IO Multiplexer
-newHasqlBroadcasterForConnection = newHasqlBroadcasterForChannel "postgres-websockets"
-
 newHasqlBroadcasterForChannel :: ByteString -> IO Connection -> IO Multiplexer
 newHasqlBroadcasterForChannel ch getCon = do
   multi <- newMultiplexer openProducer closeProducer

--- a/src/PostgresWebsockets/HasqlBroadcast.hs
+++ b/src/PostgresWebsockets/HasqlBroadcast.hs
@@ -87,7 +87,7 @@ newHasqlBroadcasterForChannel ch getCon = do
     closeProducer _ = putErrLn "Broadcaster is dead"
     toMsg :: ByteString -> ByteString -> Message
     toMsg c m = case decode (toS m) of
-                   Just v -> Message (channelDef c v) (payloadDef m v)
+                   Just v -> Message (channelDef c v) m
                    Nothing -> Message c m
 
     lookupStringDef :: Text -> ByteString -> Value -> ByteString
@@ -97,7 +97,6 @@ newHasqlBroadcasterForChannel ch getCon = do
         _ -> d
     lookupStringDef _ d _ = d
     channelDef = lookupStringDef "channel"
-    payloadDef = lookupStringDef "payload"
     openProducer msgs = do
       con <- getCon
       listen con $ toPgIdentifier ch

--- a/src/PostgresWebsockets/HasqlBroadcast.hs
+++ b/src/PostgresWebsockets/HasqlBroadcast.hs
@@ -92,7 +92,7 @@ newHasqlBroadcasterForChannel ch getCon = do
 
     lookupStringDef :: Text -> ByteString -> Value -> ByteString
     lookupStringDef key d (Object obj) =
-      case (lookupDefault (String $ toS d) key obj) of
+      case lookupDefault (String $ toS d) key obj of
         String s -> toS s
         _ -> d
     lookupStringDef _ d _ = d

--- a/test/BroadcastSpec.hs
+++ b/test/BroadcastSpec.hs
@@ -13,7 +13,7 @@ spec = do
     it "opens a separate thread for a producer function" $ do
       output <- newTQueueIO :: IO (TQueue ThreadId)
 
-      void $ liftIO $ newMultiplexer (\_ _-> do
+      void $ liftIO $ newMultiplexer (\_-> do
         tid <- myThreadId
         atomically $ writeTQueue output tid
         ) (\_ -> return ())
@@ -23,7 +23,7 @@ spec = do
   describe "relayMessages" $
     it "relays a single message from producer to 1 listener on 1 test channel" $ do
       output <- newTQueueIO :: IO (TQueue Message)
-      multi <- liftIO $ newMultiplexer (\_ msgs->
+      multi <- liftIO $ newMultiplexer (\msgs->
         atomically $ writeTQueue msgs (Message "test" "payload")) (\_ -> return ())
       void $ onMessage multi "test" $ atomically . writeTQueue output
 
@@ -31,16 +31,3 @@ spec = do
 
       outMsg <- atomically $ readTQueue output
       outMsg `shouldBe` Message "test" "payload"
-  describe "onMessage" $
-    it "sends an open command to the producer" $ do
-      output <- newTQueueIO :: IO (TQueue Text)
-      multi <- liftIO $ newMultiplexer (\cmds _->
-        atomically $ do
-          cmd <- readTQueue cmds
-          writeTQueue output (show cmd :: Text)
-        ) (\_ -> return ())
-
-      void $ onMessage multi "new channel" (\_ -> return ())
-
-      outMsg <- atomically $ readTQueue output
-      outMsg `shouldBe` "Open \"new channel\""

--- a/test/HasqlBroadcastSpec.hs
+++ b/test/HasqlBroadcastSpec.hs
@@ -24,4 +24,4 @@ spec = describe "newHasqlBroadcaster" $ do
       con <- newConnection "postgres://localhost/postgres_ws_test"
       void $ notify con (toPgIdentifier "postgres-websockets") "{\"channel\": \"test\", \"payload\": \"hello there\"}"
 
-      readMVar msg `shouldReturn` (Message "test" "hello there")
+      readMVar msg `shouldReturn` (Message "test" "{\"channel\": \"test\", \"payload\": \"hello there\"}")

--- a/test/HasqlBroadcastSpec.hs
+++ b/test/HasqlBroadcastSpec.hs
@@ -24,4 +24,4 @@ spec = describe "newHasqlBroadcaster" $ do
       con <- newConnection "postgres://localhost/postgres_ws_test"
       void $ notify con (toPgIdentifier "postgres-websockets") "{\"channel\": \"test\", \"payload\": \"hello there\"}"
 
-      readMVar msg `shouldReturn` (Message "test" "{\"channel\": \"test\", \"payload\": \"hello there\"}")
+      readMVar msg `shouldReturn` Message "test" "{\"channel\": \"test\", \"payload\": \"hello there\"}"

--- a/test/HasqlBroadcastSpec.hs
+++ b/test/HasqlBroadcastSpec.hs
@@ -17,7 +17,7 @@ spec = describe "newHasqlBroadcaster" $ do
             <$> acquire connStr
 
     it "relay messages sent to the appropriate database channel" $ do
-      multi <- either (panic .show) id <$> newHasqlBroadcasterOrError "postgres://localhost/postgres_ws_test"
+      multi <- either (panic .show) id <$> newHasqlBroadcasterOrError "postgres-websockets" "postgres://localhost/postgres_ws_test"
       msg <- liftIO newEmptyMVar
       onMessage multi "test" $ putMVar msg
 

--- a/test/HasqlBroadcastSpec.hs
+++ b/test/HasqlBroadcastSpec.hs
@@ -23,26 +23,5 @@ spec = describe "newHasqlBroadcaster" $ do
             either (panic . show) id
             <$> acquire connStr
 
-    it "start listening on a database connection as we send an Open command" $ do
-      con <- newConnection "postgres://localhost/postgres_ws_test"
-      multi <- liftIO $ newHasqlBroadcaster "postgres://localhost/postgres_ws_test"
-
-      atomically $ openChannelProducer multi "test channel"
-      threadDelay 1000000
-
-      let statement = H.statement "SELECT EXISTS (SELECT 1 FROM pg_stat_activity WHERE query ~* 'LISTEN \\\"test channel\\\"')"
-                      HE.unit (HD.singleRow $ HD.value HD.bool) False
-          query = H.query () statement
-      booleanQueryShouldReturn con query True
-
-    it "stops listening on a database connection as we send a Close command" $ do
-      con <- newConnection "postgres://localhost/postgres_ws_test"
-      multi <- liftIO $ newHasqlBroadcaster "postgres://localhost/postgres_ws_test"
-
-      atomically $ closeChannelProducer multi "test channel"
-      threadDelay 1000000
-
-      let statement = H.statement "SELECT EXISTS (SELECT 1 FROM pg_stat_activity WHERE query ~* 'UNLISTEN \\\"test channel\\\"')"
-                      HE.unit (HD.singleRow $ HD.value HD.bool) False
-          query = H.query () statement
-      booleanQueryShouldReturn con query True
+    it "relay messages sent to the appropriate database channel" $ do
+      pending


### PR DESCRIPTION
Uses only one pre-configured channel in the database to listen and send notifications to.
All channels used by webscokets are created using a json envelope in the format:

```javascript
{
  "channel": "channel_name", 
  "payload": "message content"
}
```

Now the channel must be configured in the configuration file, the old audit-channel config will be used in case the new `listen-channel` config is missing. This should provide an easier migration for users of an audit channel, since this was a channel used to receive a copy of every message.