### PR TITLE
Read configuration from environment variables.

### DIFF
--- a/postgres-websockets.cabal
+++ b/postgres-websockets.cabal
@@ -63,8 +63,9 @@ executable postgres-websockets
                      , protolude >= 0.2
                      , base64-bytestring
                      , bytestring
-                     , configurator
+                     , configurator-ng >= 0.0.0.1
                      , optparse-applicative
+                     , scientific >= 0.3.5.0
                      , text
                      , time
                      , wai

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,7 @@
 resolver: lts-9.12
 extra-deps:
-    - protolude-0.2
+  - protolude-0.2
+  - configurator-ng-0.0.0.1
+  - critbit-0.2.0.0
 ghc-options:
   postgres-websockets: -O2 -Wall -fwarn-identities -fno-warn-redundant-constraints


### PR DESCRIPTION
I need postgres-websockets to be able to read integers from environment variables, but I wasn't able to due to limitations in configurator. I solved this by replacing configurator with configurator-ng.