### PR TITLE
Jwt validate exp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Next release
+
+- Send close connection once the JWT token expires (if channel is open with a token using the `exp` claim).
+- Change the format of the timestamp sent with each message to use an integer value in nanoseconds.
+- Change the name of the field with the message delivery timestamp from `message_delivered_at` to `deliveredAt`.
+
 ## 0.6.1.0
 
 - Add capability to unset `PGWS_ROOT_PATH` to disable static file serving.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 ## Next release
 
 - Send close connection once the JWT token expires (if channel is open with a token using the `exp` claim).
-- Change the format of the timestamp sent with each message to use an integer value in nanoseconds.
-- Change the name of the field with the message delivery timestamp from `message_delivered_at` to `deliveredAt`.
 
 ## 0.6.1.0
 

--- a/client-example/screen.css
+++ b/client-example/screen.css
@@ -21,7 +21,7 @@ h2 {
 }
 
 div#main {
-    width: 600px;
+    width: 50%;
     margin: 0px auto 0px auto;
     padding: 0px;
     background-color: #fff;

--- a/postgres-websockets.cabal
+++ b/postgres-websockets.cabal
@@ -44,6 +44,7 @@ library
                      , stringsearch >= 0.3.6.6 && < 0.4
                      , time >= 1.8.0.2 && < 1.9
                      , contravariant >= 1.5.2 && < 1.6
+                     , alarmclock >= 0.7.0.2 && < 0.8
   default-language:    Haskell2010
   default-extensions: OverloadedStrings, NoImplicitPrelude, LambdaCase
 

--- a/postgres-websockets.cabal
+++ b/postgres-websockets.cabal
@@ -67,7 +67,7 @@ executable postgres-websockets
                      , wai >= 3.2 && < 4
                      , wai-extra >= 3.0.29 && < 3.1
                      , wai-app-static >= 3.1.7.1 && < 3.2
-                     , http-types
+                     , http-types >= 0.9
                      , envparse >= 0.4.1
   default-language:    Haskell2010
   default-extensions: OverloadedStrings, NoImplicitPrelude, QuasiQuotes
@@ -82,18 +82,18 @@ test-suite postgres-websockets-test
   build-depends:       base
                      , protolude >= 0.2.3
                      , postgres-websockets
-                     , containers
-                     , hspec
-                     , hspec-wai
-                     , hspec-wai-json
-                     , aeson
-                     , hasql
-                     , hasql-pool
+                     , hspec >= 2.7.1 && < 2.8
+                     , hspec-wai >= 0.9.2 && < 0.10
+                     , hspec-wai-json >= 0.9.2 && < 0.10
+                     , aeson >= 1.4.6.0 && < 1.5
+                     , hasql >= 0.19
+                     , hasql-pool >= 0.4
                      , hasql-notifications >= 0.1.0.0 && < 0.2
-                     , http-types
+                     , http-types >= 0.9
+                     , time >= 1.8.0.2 && < 1.9
                      , unordered-containers >= 0.2
-                     , wai-extra
-                     , stm
+                     , wai-extra >= 3.0.29 && < 3.1
+                     , stm >= 2.5.0.0 && < 2.6
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
   default-extensions: OverloadedStrings, NoImplicitPrelude

--- a/postgres-websockets.cabal
+++ b/postgres-websockets.cabal
@@ -69,6 +69,7 @@ executable postgres-websockets
                      , wai-app-static >= 3.1.7.1 && < 3.2
                      , http-types >= 0.9
                      , envparse >= 0.4.1
+                     , auto-update >= 0.1.6 && < 0.2
   default-language:    Haskell2010
   default-extensions: OverloadedStrings, NoImplicitPrelude, QuasiQuotes
 

--- a/src/PostgresWebsockets.hs
+++ b/src/PostgresWebsockets.hs
@@ -23,7 +23,7 @@ import qualified Data.ByteString.Lazy           as BL
 import qualified Data.HashMap.Strict            as M
 import qualified Data.Text.Encoding.Error       as T
 import           Data.Time.Clock (UTCTime)
-import           Data.Time.Clock.POSIX          (utcTimeToPOSIXSeconds, getCurrentTime, posixSecondsToUTCTime)
+import           Data.Time.Clock.POSIX          (utcTimeToPOSIXSeconds, posixSecondsToUTCTime)
 import           Control.Concurrent.AlarmClock (newAlarmClock, setAlarm)
 import           PostgresWebsockets.Broadcast          (Multiplexer, onMessage)
 import qualified PostgresWebsockets.Broadcast          as B
@@ -72,9 +72,9 @@ wsApp getTime dbChannel secret pool multi pendingConn =
           -- Fork a pinging thread to ensure browser connections stay alive
           WS.withPingThread conn 30 (pure ()) $ do
             case M.lookup "exp" validClaims of
-              Just (A.Number exp) -> do
+              Just (A.Number expClaim) -> do
                 connectionExpirer <- newAlarmClock $ const (WS.sendClose conn ("JWT expired" :: ByteString))
-                setAlarm connectionExpirer (posixSecondsToUTCTime $ realToFrac exp)
+                setAlarm connectionExpirer (posixSecondsToUTCTime $ realToFrac expClaim)
               Just _ -> pure ()
               Nothing -> pure ()
 

--- a/src/PostgresWebsockets.hs
+++ b/src/PostgresWebsockets.hs
@@ -22,7 +22,7 @@ import qualified Data.ByteString.Char8          as BS
 import qualified Data.ByteString.Lazy           as BL
 import qualified Data.HashMap.Strict            as M
 import qualified Data.Text.Encoding.Error       as T
-import           Data.Time.Clock.POSIX          (getPOSIXTime)
+import           Data.Time.Clock.POSIX          (getPOSIXTime, getCurrentTime)
 import           PostgresWebsockets.Broadcast          (Multiplexer, onMessage)
 import qualified PostgresWebsockets.Broadcast          as B
 import           PostgresWebsockets.Claims
@@ -50,7 +50,7 @@ postgresWsMiddleware =
 -- this kills all children and frees resources for us
 wsApp :: Text -> ByteString -> H.Pool -> Multiplexer -> WS.ServerApp
 wsApp dbChannel secret pool multi pendingConn =
-  validateClaims requestChannel secret (toS jwtToken) >>= either rejectRequest forkSessions
+  getCurrentTime >>= validateClaims requestChannel secret (toS jwtToken) >>= either rejectRequest forkSessions
   where
     hasRead m = m == ("r" :: ByteString) || m == ("rw" :: ByteString)
     hasWrite m = m == ("w" :: ByteString) || m == ("rw" :: ByteString)

--- a/test/ClaimsSpec.hs
+++ b/test/ClaimsSpec.hs
@@ -5,13 +5,19 @@ import           Protolude
 import qualified Data.HashMap.Strict as M
 import           Test.Hspec
 import           Data.Aeson          (Value (..) )
-
+import Data.Time.Clock
 import           PostgresWebsockets.Claims
 
 spec :: Spec
 spec =
-  describe "validate claims"
-  $ it "should succeed using a matching token"
-  $ validateClaims Nothing "reallyreallyreallyreallyverysafe"
-                   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtb2RlIjoiciIsImNoYW5uZWwiOiJ0ZXN0In0.1d4s-at2kWj8OSabHZHTbNh1dENF7NWy_r0ED3Rwf58"
+  describe "validate claims" $ do
+    it "should invalidate an expired token" $ do
+      time <- getCurrentTime
+      validateClaims Nothing "reallyreallyreallyreallyverysafe"
+                   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtb2RlIjoiciIsImNoYW5uZWwiOiJ0ZXN0IiwiZXhwIjoxfQ.4rDYiMZFR2WHB7Eq4HMdvDP_BQZVtHIfyJgy0NshbHY" time
+                   `shouldReturn` Left "Token expired"
+    it "should succeed using a matching token" $ do
+      time <- getCurrentTime
+      validateClaims Nothing "reallyreallyreallyreallyverysafe"
+                   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtb2RlIjoiciIsImNoYW5uZWwiOiJ0ZXN0In0.1d4s-at2kWj8OSabHZHTbNh1dENF7NWy_r0ED3Rwf58" time
                    `shouldReturn` Right ("test", "r", M.fromList[("mode",String "r"),("channel",String "test")])


### PR DESCRIPTION
This will send a close request to the websocket if the channel was open with a JWT containing an `exp` claim once the expiration timestamp has passed.

There is a breaking change in the format of the timestamp sent in the message, now we send the POSIX time as an Integer value in nanoseconds. This is for the sake of consistency with the way `exp` claim is represented (although with a different resolution). Since we are breaking the format I took the oportunity to rename the field to something more JSON friendly, now it's called `deliveredAt`.

This PR uses [verifyClaimsAt](https://hackage.haskell.org/package/jose-0.8.3/docs/Crypto-JWT.html#v:verifyClaimsAt) instead of [verifyClaims](https://hackage.haskell.org/package/jose-0.8.3/docs/Crypto-JWT.html#v:verifyClaims) so we can use an unified clock function avoiding wasting system resources.

It also adds the library `alarmclock` to set a concurrent timeout that will close our websocket connection.

It should address #54 