### PR TITLE
Shutdown server if listener connection dies

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -52,25 +52,32 @@ main = do
                <> " / Connects websockets to PostgreSQL asynchronous notifications."
 
   conf <- loadSecretFile =<< readOptions
+  shutdownSignal <- newEmptyMVar
   let host = configHost conf
       port = configPort conf
       listenChannel = toS $ configListenChannel conf
       pgSettings = toS (configDatabase conf)
+      waitForShutdown cl = void $ forkIO (takeMVar shutdownSignal >> cl >> die "Shutting server down...")
+
       appSettings = setHost ((fromString . toS) host)
                   . setPort port
                   . setServerName (toS $ "postgres-websockets/" <> prettyVersion)
                   . setTimeout 3600
+                  . setInstallShutdownHandler waitForShutdown
+                  . setGracefulShutdownTimeout (Just 5)
                   $ defaultSettings
 
   putStrLn $ ("Listening on port " :: Text) <> show (configPort conf)
 
+  let shutdown = putErrLn ("Broadcaster connection is dead" :: Text) >> putMVar shutdownSignal ()
   pool <- P.acquire (configPool conf, 10, pgSettings)
-  multi <- newHasqlBroadcaster listenChannel pgSettings
+  multi <- newHasqlBroadcaster shutdown listenChannel pgSettings
   getTime <- mkGetTime
 
   runSettings appSettings $
     postgresWsMiddleware getTime listenChannel (configJwtSecret conf) pool multi $
     logStdout $ maybe dummyApp staticApp' (configPath conf)
+
   where
     mkGetTime :: IO (IO UTCTime)
     mkGetTime = mkAutoUpdate defaultUpdateSettings {updateAction = getCurrentTime}

--- a/test/HasqlBroadcastSpec.hs
+++ b/test/HasqlBroadcastSpec.hs
@@ -15,7 +15,7 @@ spec = describe "newHasqlBroadcaster" $ do
             <$> acquire connStr
 
     it "relay messages sent to the appropriate database channel" $ do
-      multi <- either (panic .show) id <$> newHasqlBroadcasterOrError "postgres-websockets" "postgres://localhost/postgres_ws_test"
+      multi <- either (panic .show) id <$> newHasqlBroadcasterOrError (pure ()) "postgres-websockets" "postgres://localhost/postgres_ws_test"
       msg <- liftIO newEmptyMVar
       onMessage multi "test" $ putMVar msg
 


### PR DESCRIPTION
Should address #55 
This PR will shutdown the while process instead of trying to recover from a connection error.
Since the connection is stateful this might be the best approach in the long term, to let some supervisor respawn the service.