### PR TITLE
Add a configuration option to open a channel for metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 # CHANGELOG
 
+## 0.10.0.0
+
+- Add `PGWS_META_CHANNEL` to configure optional metadata channel to send events from the server. Initially the oply event is `ConnectionOpen`.
+- Add property `event` to message JSON. Two possible values so far: `ConnectionOpen` and `WebsocketMessage`.
+- Breaking change: the property `channel` is not appended to claims anymore. If `channel` is in the original token claims it will still be present.
+
 ## 0.9.0.0
 
 - Add @filename semantics to PGWS_DB_URI configiration variable to allow secret management to use a file instead of an environment variable.
-- Add PGWS_RETRIES to limit the amount of times the server tries to open a database connection upon startup (defaults to 5). This breaks backward compatibility if you rely on the behaviour of the server to try infitite times.
+- Add `PGWS_RETRIES` to limit the amount of times the server tries to open a database connection upon startup (defaults to 5). This breaks backward compatibility if you rely on the behaviour of the server to try infitite times.
 
 ## 0.8.0.1
 

--- a/client-example/client.js
+++ b/client-example/client.js
@@ -64,7 +64,7 @@ function jwt() {
 }
 
 $(document).ready(function () {
-    var ws = null;
+    var ws = null, meta = null;
 
     $('#channel').keyup(updateJWT);
     updateJWT();
@@ -74,6 +74,10 @@ $(document).ready(function () {
         if(ws === null){
             var jwt = $('#jwt').val();
             var channel = $('#channel').val();
+
+            meta = createWebSocket('/server-info/' + jwt);
+            meta.onmessage = onMessage('#meta-messages');
+
             if(channel == ""){
               ws = createWebSocket('/' + jwt);
             } else {

--- a/client-example/index.html
+++ b/client-example/index.html
@@ -34,6 +34,9 @@
                 <h2>Messages sent to chat channel</h2>
                 <div id="messages">
                 </div>
+                <h2>Messages sent to meta channel</h2>
+                <div id="meta-messages">
+                </div>
             </div>
         </div>
     </body>

--- a/postgres-websockets.cabal
+++ b/postgres-websockets.cabal
@@ -25,6 +25,7 @@ library
   other-modules:       Paths_postgres_websockets
                      , PostgresWebsockets.Server
                      , PostgresWebsockets.Middleware
+                     , PostgresWebsockets.Context
   build-depends:       base >= 4.7 && < 5
                      , hasql-pool >= 0.5 && < 0.6
                      , text >= 1.2 && < 1.3

--- a/postgres-websockets.cabal
+++ b/postgres-websockets.cabal
@@ -1,5 +1,5 @@
 name:                postgres-websockets
-version:             0.9.0.0
+version:             0.10.0.0
 synopsis:            Middleware to map LISTEN/NOTIFY messages to Websockets
 description:         Please see README.md
 homepage:            https://github.com/diogob/postgres-websockets#readme

--- a/sample-env
+++ b/sample-env
@@ -10,6 +10,9 @@ export PGWS_ROOT_PATH="./client-example"
 ## Sends a copy of every message received from websocket clients to the channel specified bellow as an aditional NOTIFY command.
 export PGWS_LISTEN_CHANNEL="postgres-websockets-listener"
 
+## Send postgres-websockets server events to this channel (will be sent both to the database and the connected websocket clients)
+export PGWS_META_CHANNEL="server-info"
+
 ## Host and port on which the websockets server (and the static files server) will be listening.
 export PGWS_HOST="*4"
 export PGWS_PORT=3000

--- a/src/PostgresWebsockets.hs
+++ b/src/PostgresWebsockets.hs
@@ -11,6 +11,6 @@ module PostgresWebsockets
   , postgresWsMiddleware
   ) where
 
-import           PostgresWebsockets.Middleware
-import           PostgresWebsockets.Server
-import           PostgresWebsockets.Config
+import PostgresWebsockets.Middleware ( postgresWsMiddleware )
+import PostgresWebsockets.Server ( serve )
+import PostgresWebsockets.Config ( prettyVersion, loadConfig )

--- a/src/PostgresWebsockets/Claims.hs
+++ b/src/PostgresWebsockets/Claims.hs
@@ -11,14 +11,15 @@ module PostgresWebsockets.Claims
   ( ConnectionInfo,validateClaims
   ) where
 
-import           Control.Lens
-import qualified Crypto.JOSE.Types   as JOSE.Types
-import           Crypto.JWT
-import qualified Data.HashMap.Strict as M
-import           Protolude
+import Protolude
+import Control.Lens
+import Crypto.JWT
 import Data.List
 import Data.Time.Clock (UTCTime)
+import qualified Crypto.JOSE.Types as JOSE.Types
+import qualified Data.HashMap.Strict as M
 import qualified Data.Aeson as JSON
+
 
 type Claims = M.HashMap Text JSON.Value
 type ConnectionInfo = ([ByteString], ByteString, Claims)

--- a/src/PostgresWebsockets/Config.hs
+++ b/src/PostgresWebsockets/Config.hs
@@ -31,6 +31,7 @@ data AppConfig = AppConfig {
   , configHost              :: Text
   , configPort              :: Int
   , configListenChannel     :: Text
+  , configMetaChannel       :: Maybe Text
   , configJwtSecret         :: ByteString
   , configJwtSecretIsBase64 :: Bool
   , configPool              :: Int
@@ -68,6 +69,7 @@ readOptions =
                 <*> var str "PGWS_HOST" (def "*4" <> helpDef show <> help "Address the server will listen for websocket connections")
                 <*> var auto "PGWS_PORT" (def 3000 <> helpDef show <> help "Port the server will listen for websocket connections")
                 <*> var str "PGWS_LISTEN_CHANNEL" (def "postgres-websockets-listener" <> helpDef show <> help "Master channel used in the database to send or read messages in any notification channel")
+                <*> optional (var str "PGWS_META_CHANNEL" (help "Websockets channel used to send events about the server state changes."))
                 <*> var str "PGWS_JWT_SECRET" (help "Secret used to sign JWT tokens used to open communications channels")
                 <*> var auto "PGWS_JWT_SECRET_BASE64" (def False <> helpDef show <> help "Indicate whether the JWT secret should be decoded from a base64 encoded string")
                 <*> var auto "PGWS_POOL_SIZE" (def 10 <> helpDef show <> help "How many connection to the database should be used by the connection pool")

--- a/src/PostgresWebsockets/Context.hs
+++ b/src/PostgresWebsockets/Context.hs
@@ -1,0 +1,39 @@
+{-|
+Module      : PostgresWebsockets.Context
+Description : Produce a context capable of running postgres-websockets sessions
+-}
+module PostgresWebsockets.Context
+        ( Context (..)
+        , mkContext
+        ) where
+
+import Protolude
+import Data.Time.Clock (UTCTime, getCurrentTime)
+import Control.AutoUpdate       ( defaultUpdateSettings
+                                , mkAutoUpdate
+                                , updateAction
+                                )
+import qualified Hasql.Pool as P
+
+import PostgresWebsockets.Config ( AppConfig(..) )
+import PostgresWebsockets.HasqlBroadcast (newHasqlBroadcaster)
+import PostgresWebsockets.Broadcast (Multiplexer)
+
+data Context = Context {
+    ctxConfig :: AppConfig
+  , ctxPool :: P.Pool
+  , ctxMulti :: Multiplexer
+  , ctxGetTime :: IO UTCTime
+  }
+
+-- | Given a configuration and a shutdown action (performed when the Multiplexer's listen connection dies) produces the context necessary to run sessions
+mkContext :: AppConfig -> IO () -> IO Context
+mkContext conf@AppConfig{..} shutdown = do
+  Context conf
+    <$> P.acquire (configPool, 10, pgSettings)
+    <*> newHasqlBroadcaster shutdown (toS configListenChannel) configRetries pgSettings
+    <*> mkGetTime
+  where
+    mkGetTime :: IO (IO UTCTime)
+    mkGetTime = mkAutoUpdate defaultUpdateSettings {updateAction = getCurrentTime}
+    pgSettings = toS configDatabase

--- a/src/PostgresWebsockets/HasqlBroadcast.hs
+++ b/src/PostgresWebsockets/HasqlBroadcast.hs
@@ -19,11 +19,11 @@ import Protolude hiding (putErrLn)
 
 import Hasql.Connection
 import Hasql.Notifications
-import Data.Aeson              (decode, Value(..))
-import Data.HashMap.Lazy       (lookupDefault)
+import Data.Aeson (decode, Value(..))
+import Data.HashMap.Lazy (lookupDefault)
 import Data.Either.Combinators (mapBoth)
-import Data.Function           (id)
-import Control.Retry           (RetryStatus(..), retrying, capDelay, exponentialBackoff)
+import Data.Function (id)
+import Control.Retry (RetryStatus(..), retrying, capDelay, exponentialBackoff)
 
 import PostgresWebsockets.Broadcast
 

--- a/src/PostgresWebsockets/HasqlBroadcast.hs
+++ b/src/PostgresWebsockets/HasqlBroadcast.hs
@@ -99,11 +99,11 @@ newHasqlBroadcasterForChannel onConnectionFailure ch getCon = do
         _ -> d
     lookupStringDef _ d _ = d
     channelDef = lookupStringDef "channel"
-    openProducer msgs = do
+    openProducer msgQ = do
       con <- getCon
       listen con $ toPgIdentifier ch
       waitForNotifications
-        (\c m-> atomically $ writeTQueue msgs $ toMsg c m)
+        (\c m-> atomically $ writeTQueue msgQ $ toMsg c m)
         con
 
 putErrLn :: Text -> IO ()

--- a/src/PostgresWebsockets/Middleware.hs
+++ b/src/PostgresWebsockets/Middleware.hs
@@ -91,15 +91,15 @@ wsApp Context{..} pendingConn =
                       validClaims
                       ctxGetTime
 
+            case configMetaChannel ctxConfig of
+              Nothing -> pure ()
+              Just ch -> sendNotification "Connecion Open" ch
+
             when (hasRead mode) $
               forM_ chs $ flip (onMessage ctxMulti) $ WS.sendTextData conn . B.payload
 
             when (hasWrite mode) $
               notifySession conn sendNotification chs
-
-            case configMetaChannel ctxConfig of
-              Nothing -> pure ()
-              Just ch -> sendNotification "Connecion Open" ch
 
             waitForever <- newEmptyMVar
             void $ takeMVar waitForever

--- a/src/PostgresWebsockets/Middleware.hs
+++ b/src/PostgresWebsockets/Middleware.hs
@@ -15,6 +15,7 @@ import Data.Time.Clock (UTCTime)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds, posixSecondsToUTCTime)
 import Control.Concurrent.AlarmClock (newAlarmClock, setAlarm)
 import qualified Hasql.Notifications as H
+import qualified Hasql.Pool as H
 import qualified Network.Wai as Wai
 import qualified Network.Wai.Handler.WebSockets as WS
 import qualified Network.WebSockets as WS
@@ -31,17 +32,25 @@ import PostgresWebsockets.Context ( Context(..) )
 import PostgresWebsockets.Config (AppConfig(..))
 import qualified PostgresWebsockets.Broadcast as B
 
+
+data Event =
+    WebsocketMessage
+  | ConnectionOpen
+  deriving (Show, Eq, Generic)
+
 data Message = Message
   { claims  :: A.Object
-  , channel :: Text
+  , event   :: Event
   , payload :: Text
+  , channel :: Text
   } deriving (Show, Eq, Generic)
 
+instance A.ToJSON Event
 instance A.ToJSON Message
 
 -- | Given a secret, a function to fetch the system time, a Hasql Pool and a Multiplexer this will give you a WAI middleware.
 postgresWsMiddleware :: Context -> Wai.Middleware
-postgresWsMiddleware = 
+postgresWsMiddleware =
   WS.websocketsOr WS.defaultConnectionOptions . wsApp
 
 -- private functions
@@ -85,15 +94,15 @@ wsApp Context{..} pendingConn =
               Just _ -> pure ()
               Nothing -> pure ()
 
-            let sendNotification = 
-                    relayChannelData
-                      (void . H.notifyPool ctxPool (configListenChannel ctxConfig) . toS)
-                      validClaims
-                      ctxGetTime
+            let sendNotification msg channel = sendMessageWithTimestamp $ websocketMessageForChannel msg channel
+                sendMessageToDatabase = sendToDatabase ctxPool (configListenChannel ctxConfig)
+                sendMessageWithTimestamp = timestampMessage ctxGetTime >=> sendMessageToDatabase
+                websocketMessageForChannel = Message validClaims WebsocketMessage
+                connectionOpenMessage = Message validClaims ConnectionOpen
 
             case configMetaChannel ctxConfig of
               Nothing -> pure ()
-              Just ch -> sendNotification "Connecion Open" ch
+              Just ch -> sendMessageWithTimestamp $ connectionOpenMessage (toS $ BS.intercalate "," chs) ch
 
             when (hasRead mode) $
               forM_ chs $ flip (onMessage ctxMulti) $ WS.sendTextData conn . B.payload
@@ -107,25 +116,22 @@ wsApp Context{..} pendingConn =
 -- Having both channel and claims as parameters seem redundant
 -- But it allows the function to ignore the claims structure and the source
 -- of the channel, so all claims decoding can be coded in the caller
-notifySession :: WS.Connection -> (ByteString -> Text -> IO ()) -> [ByteString] -> IO ()
+notifySession :: WS.Connection -> (Text -> Text -> IO ()) -> [ByteString] -> IO ()
 notifySession wsCon sendToChannel chs =
   withAsync (forever relayData) wait
   where
-    relayData = do 
+    relayData = do
       msg <- WS.receiveData wsCon
       forM_ chs (sendToChannel msg . toS)
 
-relayChannelData :: (ByteString -> IO ()) -> A.Object -> IO UTCTime -> ByteString -> Text -> IO ()
-relayChannelData send claimsToSend getTime msg ch =
-  claimsWithTime >>= (send . jsonMsg)
+sendToDatabase :: H.Pool -> Text -> Message -> IO ()
+sendToDatabase pool dbChannel =
+  notify . jsonMsg
   where
-    -- we need to decode the bytestring to re-encode valid JSON for the notification
-    jsonMsg :: M.HashMap Text A.Value -> ByteString
-    jsonMsg cl = BL.toStrict . A.encode . Message cl ch . decodeUtf8With T.lenientDecode $ msg
+    notify = void . H.notifyPool pool dbChannel . toS
+    jsonMsg = BL.toStrict . A.encode
 
-    claimsWithTime :: IO (M.HashMap Text A.Value)
-    claimsWithTime = do
-      time <- utcTimeToPOSIXSeconds <$> getTime
-      return $ M.insert "message_delivered_at" (A.Number $ realToFrac time) claimsWithChannel
-
-    claimsWithChannel = M.insert "channel" (A.String ch) claimsToSend
+timestampMessage :: IO UTCTime -> Message -> IO Message
+timestampMessage getTime msg@Message{..} = do
+  time <- utcTimeToPOSIXSeconds <$> getTime
+  return $ msg{ claims = M.insert "message_delivered_at" (A.Number $ realToFrac time) claims}

--- a/src/PostgresWebsockets/Server.hs
+++ b/src/PostgresWebsockets/Server.hs
@@ -6,47 +6,35 @@ module PostgresWebsockets.Server
         ( serve 
         ) where
 
-import           Protolude
-import           PostgresWebsockets.Middleware
-import           PostgresWebsockets.Config
-import           PostgresWebsockets.HasqlBroadcast (newHasqlBroadcaster)
+import Protolude
+import Network.Wai.Application.Static ( staticApp, defaultFileServerSettings )
+import Network.Wai (Application, responseLBS)
+import Network.HTTP.Types (status200)
+import Network.Wai.Handler.Warp ( runSettings )
+import Network.Wai.Middleware.RequestLogger (logStdout)
 
-import qualified Hasql.Pool as P
-import           Network.Wai.Application.Static
-import           Data.Time.Clock (UTCTime, getCurrentTime)
-import Control.AutoUpdate       ( defaultUpdateSettings
-                                , mkAutoUpdate
-                                , updateAction
-                                )
-import           Network.Wai (Application, responseLBS)
-import           Network.HTTP.Types (status200)
-import           Network.Wai.Handler.Warp
-import           Network.Wai.Middleware.RequestLogger (logStdout)
+import PostgresWebsockets.Middleware ( postgresWsMiddleware )
+import PostgresWebsockets.Config ( AppConfig(..), warpSettings )
+import PostgresWebsockets.Context ( mkContext )
 
 -- | Start a stand-alone warp server using the parameters from AppConfig and a opening a database connection pool.
 serve :: AppConfig -> IO ()
 serve conf@AppConfig{..} = do
   shutdownSignal <- newEmptyMVar
-  let listenChannel = toS configListenChannel
-      pgSettings = toS configDatabase
-      waitForShutdown cl = void $ forkIO (takeMVar shutdownSignal >> cl)
+  let waitForShutdown cl = void $ forkIO (takeMVar shutdownSignal >> cl)
       appSettings = warpSettings waitForShutdown conf
 
   putStrLn $ ("Listening on port " :: Text) <> show configPort
 
   let shutdown = putErrLn ("Broadcaster connection is dead" :: Text) >> putMVar shutdownSignal ()
-  pool <- P.acquire (configPool, 10, pgSettings)
-  multi <- newHasqlBroadcaster shutdown listenChannel configRetries pgSettings
-  getTime <- mkGetTime
+  ctx <- mkContext conf shutdown
 
   runSettings appSettings $
-    postgresWsMiddleware getTime listenChannel configJwtSecret pool multi $
+    postgresWsMiddleware ctx $
     logStdout $ maybe dummyApp staticApp' configPath
   die "Shutting down server..."
 
   where
-    mkGetTime :: IO (IO UTCTime)
-    mkGetTime = mkAutoUpdate defaultUpdateSettings {updateAction = getCurrentTime}
     staticApp' :: Text -> Application
     staticApp' = staticApp . defaultFileServerSettings . toS
     dummyApp :: Application

--- a/test/ServerSpec.hs
+++ b/test/ServerSpec.hs
@@ -20,8 +20,10 @@ testServerConfig = AppConfig
                     , configPort = 8080
                     , configListenChannel = "postgres-websockets-test-channel"
                     , configJwtSecret = "reallyreallyreallyreallyverysafe"
+                    , configMetaChannel = Nothing
                     , configJwtSecretIsBase64 = False
                     , configPool = 10
+                    , configRetries = 5
                     }
 
 startTestServer :: IO ThreadId

--- a/test/ServerSpec.hs
+++ b/test/ServerSpec.hs
@@ -13,7 +13,7 @@ import qualified Network.WebSockets as WS
 import           Network.Socket (withSocketsDo)
 
 testServerConfig :: AppConfig
-testServerConfig = AppConfig 
+testServerConfig = AppConfig
                     { configDatabase = "postgres://localhost/postgres"
                     , configPath = Nothing
                     , configHost = "*"
@@ -29,22 +29,22 @@ testServerConfig = AppConfig
 startTestServer :: IO ThreadId
 startTestServer = do
     threadId <- forkIO $ serve testServerConfig
-    threadDelay 1000
+    threadDelay 500000
     pure threadId
 
 withServer :: IO () -> IO ()
 withServer action =
   bracket startTestServer
-          killThread
+          (\tid -> killThread tid >> threadDelay 500000)
           (const action)
 
 sendWsData :: Text -> Text -> IO ()
 sendWsData uri msg =
-    withSocketsDo $ 
-        WS.runClient 
-            "localhost" 
-            (configPort testServerConfig) 
-            (toS uri) 
+    withSocketsDo $
+        WS.runClient
+            "localhost"
+            (configPort testServerConfig)
+            (toS uri)
             (`WS.sendTextData` msg)
 
 testChannel :: Text
@@ -60,27 +60,27 @@ waitForWsData :: Text -> IO (MVar ByteString)
 waitForWsData uri = do
     msg <- newEmptyMVar
     void $ forkIO $
-        withSocketsDo $ 
-            WS.runClient 
-                "localhost" 
-                (configPort testServerConfig) 
-                (toS uri) 
+        withSocketsDo $
+            WS.runClient
+                "localhost"
+                (configPort testServerConfig)
+                (toS uri)
                 (\c -> do
                     m <- WS.receiveData c
                     putMVar msg m
                 )
-    threadDelay 1000
+    threadDelay 10000
     pure msg
 
 waitForMultipleWsData :: Int -> Text -> IO (MVar [ByteString])
 waitForMultipleWsData messageCount uri = do
     msg <- newEmptyMVar
     void $ forkIO $
-        withSocketsDo $ 
-            WS.runClient 
-                "localhost" 
-                (configPort testServerConfig) 
-                (toS uri) 
+        withSocketsDo $
+            WS.runClient
+                "localhost"
+                (configPort testServerConfig)
+                (toS uri)
                 (\c -> do
                     m <- replicateM messageCount (WS.receiveData c)
                     putMVar msg m
@@ -114,6 +114,6 @@ spec = around_ withServer $
                     sendWsData testAndSecondaryChannel "test data"
                     msgsJson <- takeMVar msgs
 
-                    forM_ 
-                        msgsJson 
+                    forM_
+                        msgsJson
                         (\msgJson -> (msgJson ^? key "payload" . _String) `shouldBe` Just "test data")


### PR DESCRIPTION
This is an attempt to create a feature that can be used to implement both #41 and #52.

The feature behaviour can be summarized as:

1. A configuration option may define a channel used for sending metadata
1. Once this configuration is enabled that channel allow only read sessions to be open.
1. Once this configuration is enabled all meta-data is sent to that channel on internal state changes through a PostgreSQL notification. Initial implementation would send messages on new websocket sessions. The metadata for the initial implementation is the JWT claims and the Multiplexer state.

This would allow executing custom functions in the database provided you have a process listening on the postgres-websockets listen channel that can call custom functions (see [pg-recorder](https://github.com/diogob/pg-recorder) for an example).

It can also be used to detect state changes in web clients that have a proper token to read the meta-data channel.

The number of connections in applications like a chat can be inferred just by the number of listeners in the `Multiplexer`. 

To get the number of connections in more complex scenarios (with write-only sessions) we would need to track websockets connections closing (which won't be a part of this PR). 