### PR TITLE
Create a listener connection supervisor so we can recover in case of database connection failure

### DIFF
--- a/sample-env
+++ b/sample-env
@@ -21,3 +21,7 @@ export PGWS_PORT=3000
 ## (use "@filename" to load from separate file)
 export PGWS_JWT_SECRET="auwhfdnskjhewfi34uwehdlaehsfkuaeiskjnfduierhfsiweskjcnzeiluwhskdewishdnpwe"
 export PGWS_JWT_SECRET_BASE64=False
+
+## Check database listener every 10 seconds
+## comment it out to disable and shutdown the server on listener errors (can be useful when using external process supervisors)
+export PGWS_CHECK_LISTENER_INTERVAL=10000

--- a/src/PostgresWebsockets/Broadcast.hs
+++ b/src/PostgresWebsockets/Broadcast.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveGeneric #-}
+
 -- |
 -- Module      : PostgresWebsockets.Broadcast
 -- Description : Distribute messages from one producer to several consumers.
@@ -26,8 +28,9 @@ where
 
 import Control.Concurrent.STM.TChan
 import Control.Concurrent.STM.TQueue
+import qualified Data.Aeson as A
 import Protolude hiding (toS)
-import Protolude.Conv
+import Protolude.Conv (toS)
 import qualified StmContainers.Map as M
 
 data Message = Message
@@ -43,10 +46,19 @@ data Multiplexer = Multiplexer
     reopenProducer :: IO ThreadId
   }
 
+data MultiplexerSnapshot = MultiplexerSnapshot
+  { channelsSize :: Int,
+    messageQueueEmpty :: Bool,
+    producerId :: Text
+  }
+  deriving (Generic)
+
 data Channel = Channel
   { broadcast :: TChan Message,
     listeners :: Integer
   }
+
+instance A.ToJSON MultiplexerSnapshot
 
 -- | Opens a thread that relays messages from the producer thread to the channels forever
 relayMessagesForever :: Multiplexer -> IO ThreadId

--- a/src/PostgresWebsockets/Claims.hs
+++ b/src/PostgresWebsockets/Claims.hs
@@ -23,13 +23,13 @@ import qualified Data.Aeson as JSON
 
 
 type Claims = M.HashMap Text JSON.Value
-type ConnectionInfo = ([ByteString], ByteString, Claims)
+type ConnectionInfo = ([Text], Text, Claims)
 
 {-| Given a secret, a token and a timestamp it validates the claims and returns
     either an error message or a triple containing channel, mode and claims hashmap.
 -}
 validateClaims
-  :: Maybe ByteString
+  :: Maybe Text
   -> ByteString
   -> LByteString
   -> UTCTime
@@ -58,16 +58,16 @@ validateClaims requestChannel secret jwtToken time = runExceptT $ do
   pure (validChannels, mode, cl')
 
  where
-  claimAsJSON :: Text -> Claims -> Maybe ByteString
+  claimAsJSON :: Text -> Claims -> Maybe Text
   claimAsJSON name cl = case M.lookup name cl of
-    Just (JSON.String s) -> Just $ encodeUtf8 s
+    Just (JSON.String s) -> Just s
     _ -> Nothing
 
-  claimAsJSONList :: Text -> Claims -> Maybe [ByteString]
+  claimAsJSONList :: Text -> Claims -> Maybe [Text]
   claimAsJSONList name cl = case M.lookup name cl of
     Just channelsJson ->
       case JSON.fromJSON channelsJson :: JSON.Result [Text] of
-        JSON.Success channelsList -> Just $ encodeUtf8 <$> channelsList
+        JSON.Success channelsList -> Just channelsList
         _ -> Nothing
     Nothing -> Nothing
 

--- a/src/PostgresWebsockets/Config.hs
+++ b/src/PostgresWebsockets/Config.hs
@@ -1,43 +1,43 @@
-{-|
-Module      : PostgresWebsockets.Config
-Description : Manages PostgresWebsockets configuration options.
+-- |
+-- Module      : PostgresWebsockets.Config
+-- Description : Manages PostgresWebsockets configuration options.
+--
+-- This module provides a helper function to read the command line
+-- arguments using  the AppConfig type to store
+-- them.  It also can be used to define other middleware configuration that
+-- may be delegated to some sort of external configuration.
+module PostgresWebsockets.Config
+  ( prettyVersion,
+    loadConfig,
+    warpSettings,
+    AppConfig (..),
+  )
+where
 
-This module provides a helper function to read the command line
-arguments using  the AppConfig type to store
-them.  It also can be used to define other middleware configuration that
-may be delegated to some sort of external configuration.
--}
-module PostgresWebsockets.Config 
-        ( prettyVersion
-        , loadConfig
-        , warpSettings
-        , AppConfig (..)
-        ) where
-
-import           Env
-import           Data.Text                   (intercalate, pack, replace, strip, stripPrefix)
-import           Data.Version                (versionBranch)
-import           Paths_postgres_websockets   (version)
-import           Protolude hiding            (intercalate, (<>), optional, replace, toS)
-import           Protolude.Conv
-import           Data.String (IsString(..))
-import           Network.Wai.Handler.Warp
-import qualified Data.ByteString                      as BS
-import qualified Data.ByteString.Base64               as B64
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base64 as B64
+import Data.String (IsString (..))
+import Data.Text (intercalate, pack, replace, strip, stripPrefix)
+import Data.Version (versionBranch)
+import Env
+import Network.Wai.Handler.Warp
+import Paths_postgres_websockets (version)
+import Protolude hiding (intercalate, optional, replace, toS, (<>))
+import Protolude.Conv
 
 -- | Config file settings for the server
-data AppConfig = AppConfig {
-    configDatabase          :: Text
-  , configPath              :: Maybe Text
-  , configHost              :: Text
-  , configPort              :: Int
-  , configListenChannel     :: Text
-  , configMetaChannel       :: Maybe Text
-  , configJwtSecret         :: ByteString
-  , configJwtSecretIsBase64 :: Bool
-  , configPool              :: Int
-  , configRetries           :: Int
-  , configReconnectInterval :: Int
+data AppConfig = AppConfig
+  { configDatabase :: Text,
+    configPath :: Maybe Text,
+    configHost :: Text,
+    configPort :: Int,
+    configListenChannel :: Text,
+    configMetaChannel :: Maybe Text,
+    configJwtSecret :: ByteString,
+    configJwtSecretIsBase64 :: Bool,
+    configPool :: Int,
+    configRetries :: Int,
+    configReconnectInterval :: Maybe Int
   }
 
 -- | User friendly version number
@@ -50,38 +50,37 @@ loadConfig = readOptions >>= loadSecretFile >>= loadDatabaseURIFile
 
 -- | Given a shutdown handler and an AppConfig builds a Warp Settings to start a stand-alone server
 warpSettings :: (IO () -> IO ()) -> AppConfig -> Settings
-warpSettings waitForShutdown AppConfig{..} =
-      setHost (fromString $ toS configHost)
-                  . setPort configPort
-                  . setServerName (toS $ "postgres-websockets/" <> prettyVersion)
-                  . setTimeout 3600
-                  . setInstallShutdownHandler waitForShutdown
-                  . setGracefulShutdownTimeout (Just 5)
-                  $ defaultSettings
-
+warpSettings waitForShutdown AppConfig {..} =
+  setHost (fromString $ toS configHost)
+    . setPort configPort
+    . setServerName (toS $ "postgres-websockets/" <> prettyVersion)
+    . setTimeout 3600
+    . setInstallShutdownHandler waitForShutdown
+    . setGracefulShutdownTimeout (Just 5)
+    $ defaultSettings
 
 -- private
 
 -- | Function to read and parse options from the environment
 readOptions :: IO AppConfig
 readOptions =
-    Env.parse (header "You need to configure some environment variables to start the service.") $
-      AppConfig <$> var (str <=< nonempty) "PGWS_DB_URI"  (help "String to connect to PostgreSQL")
-                <*> optional (var str "PGWS_ROOT_PATH" (help "Root path to serve static files, unset to disable."))
-                <*> var str "PGWS_HOST" (def "*4" <> helpDef show <> help "Address the server will listen for websocket connections")
-                <*> var auto "PGWS_PORT" (def 3000 <> helpDef show <> help "Port the server will listen for websocket connections")
-                <*> var str "PGWS_LISTEN_CHANNEL" (def "postgres-websockets-listener" <> helpDef show <> help "Master channel used in the database to send or read messages in any notification channel")
-                <*> optional (var str "PGWS_META_CHANNEL" (help "Websockets channel used to send events about the server state changes."))
-                <*> var str "PGWS_JWT_SECRET" (help "Secret used to sign JWT tokens used to open communications channels")
-                <*> var auto "PGWS_JWT_SECRET_BASE64" (def False <> helpDef show <> help "Indicate whether the JWT secret should be decoded from a base64 encoded string")
-                <*> var auto "PGWS_POOL_SIZE" (def 10 <> helpDef show <> help "How many connection to the database should be used by the connection pool")
-                <*> var auto "PGWS_RETRIES" (def 5 <> helpDef show <> help "How many times it should try to connect to the database on startup before exiting with an error")
-                <*> var auto "PGWS_CHECK_LISTENER_INTERVAL" (def 0 <> helpDef show <> help "Interval for supervisor thread to check if listener connection is alive. 0 to disable it.")
+  Env.parse (header "You need to configure some environment variables to start the service.") $
+    AppConfig <$> var (str <=< nonempty) "PGWS_DB_URI" (help "String to connect to PostgreSQL")
+      <*> optional (var str "PGWS_ROOT_PATH" (help "Root path to serve static files, unset to disable."))
+      <*> var str "PGWS_HOST" (def "*4" <> helpDef show <> help "Address the server will listen for websocket connections")
+      <*> var auto "PGWS_PORT" (def 3000 <> helpDef show <> help "Port the server will listen for websocket connections")
+      <*> var str "PGWS_LISTEN_CHANNEL" (def "postgres-websockets-listener" <> helpDef show <> help "Master channel used in the database to send or read messages in any notification channel")
+      <*> optional (var str "PGWS_META_CHANNEL" (help "Websockets channel used to send events about the server state changes."))
+      <*> var str "PGWS_JWT_SECRET" (help "Secret used to sign JWT tokens used to open communications channels")
+      <*> var auto "PGWS_JWT_SECRET_BASE64" (def False <> helpDef show <> help "Indicate whether the JWT secret should be decoded from a base64 encoded string")
+      <*> var auto "PGWS_POOL_SIZE" (def 10 <> helpDef show <> help "How many connection to the database should be used by the connection pool")
+      <*> var auto "PGWS_RETRIES" (def 5 <> helpDef show <> help "How many times it should try to connect to the database on startup before exiting with an error")
+      <*> optional (var auto "PGWS_CHECK_LISTENER_INTERVAL" (helpDef show <> help "Interval for supervisor thread to check if listener connection is alive. 0 to disable it."))
 
 loadDatabaseURIFile :: AppConfig -> IO AppConfig
-loadDatabaseURIFile conf@AppConfig{..} =
+loadDatabaseURIFile conf@AppConfig {..} =
   case stripPrefix "@" configDatabase of
-    Nothing       -> pure conf
+    Nothing -> pure conf
     Just filename -> setDatabase . strip <$> readFile (toS filename)
   where
     setDatabase uri = conf {configDatabase = uri}
@@ -89,15 +88,16 @@ loadDatabaseURIFile conf@AppConfig{..} =
 loadSecretFile :: AppConfig -> IO AppConfig
 loadSecretFile conf = extractAndTransform secret
   where
-    secret   = decodeUtf8 $ configJwtSecret conf
-    isB64     = configJwtSecretIsBase64 conf
+    secret = decodeUtf8 $ configJwtSecret conf
+    isB64 = configJwtSecretIsBase64 conf
 
     extractAndTransform :: Text -> IO AppConfig
     extractAndTransform s =
-      fmap setSecret $ transformString isB64 =<<
-        case stripPrefix "@" s of
-          Nothing       -> return . encodeUtf8 $ s
-          Just filename -> chomp <$> BS.readFile (toS filename)
+      fmap setSecret $
+        transformString isB64
+          =<< case stripPrefix "@" s of
+            Nothing -> return . encodeUtf8 $ s
+            Just filename -> chomp <$> BS.readFile (toS filename)
       where
         chomp bs = fromMaybe bs (BS.stripSuffix "\n" bs)
 
@@ -107,11 +107,10 @@ loadSecretFile conf = extractAndTransform secret
     transformString True t =
       case B64.decode $ encodeUtf8 $ strip $ replaceUrlChars $ decodeUtf8 t of
         Left errMsg -> panic $ pack errMsg
-        Right bs    -> return bs
+        Right bs -> return bs
 
     setSecret bs = conf {configJwtSecret = bs}
 
     -- replace: Replace every occurrence of one substring with another
     replaceUrlChars =
       replace "_" "/" . replace "-" "+" . replace "." "="
-

--- a/src/PostgresWebsockets/Config.hs
+++ b/src/PostgresWebsockets/Config.hs
@@ -37,6 +37,7 @@ data AppConfig = AppConfig {
   , configJwtSecretIsBase64 :: Bool
   , configPool              :: Int
   , configRetries           :: Int
+  , configReconnectInterval :: Int
   }
 
 -- | User friendly version number
@@ -75,6 +76,7 @@ readOptions =
                 <*> var auto "PGWS_JWT_SECRET_BASE64" (def False <> helpDef show <> help "Indicate whether the JWT secret should be decoded from a base64 encoded string")
                 <*> var auto "PGWS_POOL_SIZE" (def 10 <> helpDef show <> help "How many connection to the database should be used by the connection pool")
                 <*> var auto "PGWS_RETRIES" (def 5 <> helpDef show <> help "How many times it should try to connect to the database on startup before exiting with an error")
+                <*> var auto "PGWS_CHECK_LISTENER_INTERVAL" (def 0 <> helpDef show <> help "Interval for supervisor thread to check if listener connection is alive. 0 to disable it.")
 
 loadDatabaseURIFile :: AppConfig -> IO AppConfig
 loadDatabaseURIFile conf@AppConfig{..} =

--- a/src/PostgresWebsockets/Context.hs
+++ b/src/PostgresWebsockets/Context.hs
@@ -1,40 +1,45 @@
-{-|
-Module      : PostgresWebsockets.Context
-Description : Produce a context capable of running postgres-websockets sessions
--}
+-- |
+-- Module      : PostgresWebsockets.Context
+-- Description : Produce a context capable of running postgres-websockets sessions
 module PostgresWebsockets.Context
-        ( Context (..)
-        , mkContext
-        ) where
+  ( Context (..),
+    mkContext,
+  )
+where
 
+import Control.AutoUpdate
+  ( defaultUpdateSettings,
+    mkAutoUpdate,
+    updateAction,
+  )
+import Data.Time.Clock (UTCTime, getCurrentTime)
+import qualified Hasql.Pool as P
+import PostgresWebsockets.Broadcast (Multiplexer)
+import PostgresWebsockets.Config (AppConfig (..))
+import PostgresWebsockets.HasqlBroadcast (newHasqlBroadcaster)
 import Protolude hiding (toS)
 import Protolude.Conv
-import Data.Time.Clock (UTCTime, getCurrentTime)
-import Control.AutoUpdate       ( defaultUpdateSettings
-                                , mkAutoUpdate
-                                , updateAction
-                                )
-import qualified Hasql.Pool as P
 
-import PostgresWebsockets.Config ( AppConfig(..) )
-import PostgresWebsockets.HasqlBroadcast (newHasqlBroadcaster)
-import PostgresWebsockets.Broadcast (Multiplexer)
-
-data Context = Context {
-    ctxConfig :: AppConfig
-  , ctxPool :: P.Pool
-  , ctxMulti :: Multiplexer
-  , ctxGetTime :: IO UTCTime
+data Context = Context
+  { ctxConfig :: AppConfig,
+    ctxPool :: P.Pool,
+    ctxMulti :: Multiplexer,
+    ctxGetTime :: IO UTCTime
   }
 
 -- | Given a configuration and a shutdown action (performed when the Multiplexer's listen connection dies) produces the context necessary to run sessions
 mkContext :: AppConfig -> IO () -> IO Context
-mkContext conf@AppConfig{..} shutdown = do
+mkContext conf@AppConfig {..} shutdownServer = do
   Context conf
     <$> P.acquire (configPool, 10, pgSettings)
     <*> newHasqlBroadcaster shutdown (toS configListenChannel) configRetries configReconnectInterval pgSettings
     <*> mkGetTime
   where
+    shutdown =
+      maybe
+        shutdownServer
+        (const $ putText "Producer thread is dead")
+        configReconnectInterval
     mkGetTime :: IO (IO UTCTime)
     mkGetTime = mkAutoUpdate defaultUpdateSettings {updateAction = getCurrentTime}
     pgSettings = toS configDatabase

--- a/src/PostgresWebsockets/Context.hs
+++ b/src/PostgresWebsockets/Context.hs
@@ -32,7 +32,7 @@ mkContext :: AppConfig -> IO () -> IO Context
 mkContext conf@AppConfig{..} shutdown = do
   Context conf
     <$> P.acquire (configPool, 10, pgSettings)
-    <*> newHasqlBroadcaster shutdown (toS configListenChannel) configRetries pgSettings
+    <*> newHasqlBroadcaster shutdown (toS configListenChannel) configRetries configReconnectInterval pgSettings
     <*> mkGetTime
   where
     mkGetTime :: IO (IO UTCTime)

--- a/src/PostgresWebsockets/HasqlBroadcast.hs
+++ b/src/PostgresWebsockets/HasqlBroadcast.hs
@@ -1,50 +1,50 @@
-{-| 
-Module      : PostgresWebsockets.Broadcast
-Description : Build a Hasql.Notifications based producer 'Multiplexer'.
-
-Uses Broadcast module adding database as a source producer.
-This module provides a function to produce a 'Multiplexer' from a Hasql 'Connection'.
-The producer issues a LISTEN command upon Open commands and UNLISTEN upon Close.
--}
+-- |
+-- Module      : PostgresWebsockets.Broadcast
+-- Description : Build a Hasql.Notifications based producer 'Multiplexer'.
+--
+-- Uses Broadcast module adding database as a source producer.
+-- This module provides a function to produce a 'Multiplexer' from a Hasql 'Connection'.
+-- The producer issues a LISTEN command upon Open commands and UNLISTEN upon Close.
 module PostgresWebsockets.HasqlBroadcast
-  ( newHasqlBroadcaster
-  , newHasqlBroadcasterOrError
-  -- re-export
-  , acquire
-  , relayMessages
-  , relayMessagesForever
-  ) where
+  ( newHasqlBroadcaster,
+    newHasqlBroadcasterOrError,
+    -- re-export
+    acquire,
+    relayMessages,
+    relayMessagesForever,
+  )
+where
 
-import Protolude hiding (putErrLn, toS, show)
-import GHC.Show
-import Protolude.Conv
-
-import Hasql.Connection
-import Hasql.Notifications
-import Data.Aeson (decode, Value(..))
-import Data.HashMap.Lazy (lookupDefault)
+import Control.Retry (RetryStatus (..), capDelay, exponentialBackoff, retrying)
+import Data.Aeson (Value (..), decode)
 import Data.Either.Combinators (mapBoth)
 import Data.Function (id)
-import Control.Retry (RetryStatus(..), retrying, capDelay, exponentialBackoff)
-
+import Data.HashMap.Lazy (lookupDefault)
+import GHC.Show
+import Hasql.Connection
+import qualified Hasql.Decoders as HD
+import qualified Hasql.Encoders as HE
+import Hasql.Notifications
+import qualified Hasql.Session as H
+import qualified Hasql.Statement as H
 import PostgresWebsockets.Broadcast
+import Protolude hiding (putErrLn, show, toS)
+import Protolude.Conv
 
-{- | Returns a multiplexer from a connection URI, keeps trying to connect in case there is any error.
-   This function also spawns a thread that keeps relaying the messages from the database to the multiplexer's listeners
--}
-newHasqlBroadcaster :: IO () -> Text -> Int -> Int -> ByteString -> IO Multiplexer
+-- | Returns a multiplexer from a connection URI, keeps trying to connect in case there is any error.
+--   This function also spawns a thread that keeps relaying the messages from the database to the multiplexer's listeners
+newHasqlBroadcaster :: IO () -> Text -> Int -> Maybe Int -> ByteString -> IO Multiplexer
 newHasqlBroadcaster onConnectionFailure ch maxRetries checkInterval = newHasqlBroadcasterForConnection . tryUntilConnected maxRetries
   where
     newHasqlBroadcasterForConnection = newHasqlBroadcasterForChannel onConnectionFailure ch checkInterval
 
-{- | Returns a multiplexer from a connection URI or an error message on the left case
-   This function also spawns a thread that keeps relaying the messages from the database to the multiplexer's listeners
--}
+-- | Returns a multiplexer from a connection URI or an error message on the left case
+--   This function also spawns a thread that keeps relaying the messages from the database to the multiplexer's listeners
 newHasqlBroadcasterOrError :: IO () -> Text -> ByteString -> IO (Either ByteString Multiplexer)
 newHasqlBroadcasterOrError onConnectionFailure ch =
   acquire >=> (sequence . mapBoth (toSL . show) (newHasqlBroadcasterForConnection . return))
   where
-    newHasqlBroadcasterForConnection = newHasqlBroadcasterForChannel onConnectionFailure ch 0
+    newHasqlBroadcasterForConnection = newHasqlBroadcasterForChannel onConnectionFailure ch Nothing
 
 tryUntilConnected :: Int -> ByteString -> IO Connection
 tryUntilConnected maxRetries =
@@ -55,44 +55,46 @@ tryUntilConnected maxRetries =
     firstDelayInMicroseconds = 1000000
     retryPolicy = capDelay maxDelayInMicroseconds $ exponentialBackoff firstDelayInMicroseconds
     shouldRetry :: RetryStatus -> Either ConnectionError Connection -> IO Bool
-    shouldRetry RetryStatus{..} con =
+    shouldRetry RetryStatus {..} con =
       case con of
         Left err -> do
           putErrLn $ "Error connecting notification listener to database: " <> (toS . show) err
           pure $ rsIterNumber < maxRetries - 1
         _ -> return False
 
-{- | Returns a multiplexer from a channel and an IO Connection, listen for different database notifications on the provided channel using the connection produced.
-
-   This function also spawns a thread that keeps relaying the messages from the database to the multiplexer's listeners
-
-   To listen on channels *chat*
-
-   @
-   import Protolude
-   import PostgresWebsockets.HasqlBroadcast
-   import PostgresWebsockets.Broadcast
-   import Hasql.Connection
-
-   main = do
-    conOrError <- H.acquire "postgres://localhost/test_database"
-    let con = either (panic . show) id conOrError :: Connection
-    multi <- newHasqlBroadcaster con
-
-    onMessage multi "chat" (\ch ->
-      forever $ fmap print (atomically $ readTChan ch)
-   @
--}
-newHasqlBroadcasterForChannel :: IO () -> Text -> Int -> IO Connection -> IO Multiplexer
+-- | Returns a multiplexer from a channel and an IO Connection, listen for different database notifications on the provided channel using the connection produced.
+--
+--   This function also spawns a thread that keeps relaying the messages from the database to the multiplexer's listeners
+--
+--   To listen on channels *chat*
+--
+--   @
+--   import Protolude
+--   import PostgresWebsockets.HasqlBroadcast
+--   import PostgresWebsockets.Broadcast
+--   import Hasql.Connection
+--
+--   main = do
+--    conOrError <- H.acquire "postgres://localhost/test_database"
+--    let con = either (panic . show) id conOrError :: Connection
+--    multi <- newHasqlBroadcaster con
+--
+--    onMessage multi "chat" (\ch ->
+--      forever $ fmap print (atomically $ readTChan ch)
+--   @
+newHasqlBroadcasterForChannel :: IO () -> Text -> Maybe Int -> IO Connection -> IO Multiplexer
 newHasqlBroadcasterForChannel onConnectionFailure ch checkInterval getCon = do
   multi <- newMultiplexer openProducer $ const onConnectionFailure
+  case checkInterval of
+    Just i -> superviseMultiplexer multi i shouldRestart
+    _ -> pure ()
   void $ relayMessagesForever multi
   return multi
   where
     toMsg :: Text -> Text -> Message
     toMsg c m = case decode (toS m) of
-                   Just v -> Message (channelDef c v) m
-                   Nothing -> Message c m
+      Just v -> Message (channelDef c v) m
+      Nothing -> Message c m
 
     lookupStringDef :: Text -> Text -> Value -> Text
     lookupStringDef key d (Object obj) =
@@ -101,12 +103,32 @@ newHasqlBroadcasterForChannel onConnectionFailure ch checkInterval getCon = do
         _ -> toS d
     lookupStringDef _ d _ = toS d
     channelDef = lookupStringDef "channel"
+    shouldRestart = do
+      con <- getCon
+      not <$> isListening con ch
+
     openProducer msgQ = do
       con <- getCon
       listen con $ toPgIdentifier ch
       waitForNotifications
-        (\c m-> atomically $ writeTQueue msgQ $ toMsg (toS c) (toS m))
+        (\c m -> atomically $ writeTQueue msgQ $ toMsg (toS c) (toS m))
         con
 
 putErrLn :: Text -> IO ()
 putErrLn = hPutStrLn stderr
+
+isListening :: Connection -> Text -> IO Bool
+isListening con ch = do
+  resultOrError <- H.run session con
+  pure $ fromRight False resultOrError
+  where
+    session = H.statement chPattern isListeningStatement
+    chPattern = "listen%" <> ch <> "%"
+
+isListeningStatement :: H.Statement Text Bool
+isListeningStatement =
+  H.Statement sql encoder decoder True
+  where
+    sql = "select exists (select * from pg_stat_activity where datname = current_database() and query ilike $1);"
+    encoder = HE.param $ HE.nonNullable HE.text
+    decoder = HD.singleRow (HD.column (HD.nonNullable HD.bool))

--- a/src/PostgresWebsockets/HasqlBroadcast.hs
+++ b/src/PostgresWebsockets/HasqlBroadcast.hs
@@ -89,23 +89,23 @@ newHasqlBroadcasterForChannel onConnectionFailure ch checkInterval getCon = do
   void $ relayMessagesForever multi
   return multi
   where
-    toMsg :: ByteString -> ByteString -> Message
+    toMsg :: Text -> Text -> Message
     toMsg c m = case decode (toS m) of
                    Just v -> Message (channelDef c v) m
                    Nothing -> Message c m
 
-    lookupStringDef :: Text -> ByteString -> Value -> ByteString
+    lookupStringDef :: Text -> Text -> Value -> Text
     lookupStringDef key d (Object obj) =
       case lookupDefault (String $ toS d) key obj of
         String s -> toS s
-        _ -> d
-    lookupStringDef _ d _ = d
+        _ -> toS d
+    lookupStringDef _ d _ = toS d
     channelDef = lookupStringDef "channel"
     openProducer msgQ = do
       con <- getCon
       listen con $ toPgIdentifier ch
       waitForNotifications
-        (\c m-> atomically $ writeTQueue msgQ $ toMsg c m)
+        (\c m-> atomically $ writeTQueue msgQ $ toMsg (toS c) (toS m))
         con
 
 putErrLn :: Text -> IO ()

--- a/test/ClaimsSpec.hs
+++ b/test/ClaimsSpec.hs
@@ -21,12 +21,12 @@ spec =
         `shouldReturn` Left "Token expired"
     it "request any channel from a token that does not have channels or channel claims should succeed" $ do
       time <- getCurrentTime
-      validateClaims (Just (encodeUtf8 "test")) secret
+      validateClaims (Just "test") secret
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtb2RlIjoiciJ9.jL5SsRFegNUlbBm8_okhHSujqLcKKZdDglfdqNl1_rY" time
         `shouldReturn` Right (["test"], "r", M.fromList[("mode",String "r")])
     it "requesting a channel that is set by and old style channel claim should work" $ do
       time <- getCurrentTime
-      validateClaims (Just (encodeUtf8 "test")) secret
+      validateClaims (Just "test") secret
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtb2RlIjoiciIsImNoYW5uZWwiOiJ0ZXN0In0.1d4s-at2kWj8OSabHZHTbNh1dENF7NWy_r0ED3Rwf58" time
         `shouldReturn` Right (["test"], "r", M.fromList[("mode",String "r"),("channel",String "test")])
     it "no requesting channel should return all channels in the token" $ do
@@ -37,18 +37,18 @@ spec =
 
     it "requesting a channel from the channels claim shoud return only the requested channel" $ do
       time <- getCurrentTime
-      validateClaims (Just (encodeUtf8 "test")) secret
+      validateClaims (Just "test") secret
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtb2RlIjoiciIsImNoYW5uZWxzIjpbInRlc3QiLCJ0ZXN0MiJdfQ.MumdJ5FpFX4Z6SJD3qsygVF0r9vqxfqhj5J30O32N0k" time
         `shouldReturn` Right (["test"], "r", M.fromList[("mode",String "r"),("channels",  toJSON ["test"::Text, "test2"] )])
 
     it "requesting a channel not from the channels claim shoud error" $ do
       time <- getCurrentTime
-      validateClaims (Just (encodeUtf8 "notAllowed")) secret
+      validateClaims (Just "notAllowed") secret
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtb2RlIjoiciIsImNoYW5uZWxzIjpbInRlc3QiLCJ0ZXN0MiJdfQ.MumdJ5FpFX4Z6SJD3qsygVF0r9vqxfqhj5J30O32N0k" time
         `shouldReturn` Left  "No allowed channels"
 
     it "requesting a channel with no mode fails" $ do
       time <- getCurrentTime
-      validateClaims (Just (encodeUtf8 "test")) secret
+      validateClaims (Just "test") secret
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjaGFubmVscyI6WyJ0ZXN0IiwidGVzdDIiXX0.akC1PEYk2DEZtLP2XjC6qXOGZJejmPx49qv-VeEtQYQ" time
         `shouldReturn` Left "Missing mode"

--- a/test/ServerSpec.hs
+++ b/test/ServerSpec.hs
@@ -24,6 +24,7 @@ testServerConfig = AppConfig
                     , configJwtSecretIsBase64 = False
                     , configPool = 10
                     , configRetries = 5
+                    , configReconnectInterval  = 0
                     }
 
 startTestServer :: IO ThreadId

--- a/test/ServerSpec.hs
+++ b/test/ServerSpec.hs
@@ -1,52 +1,51 @@
 module ServerSpec (spec) where
 
-import Protolude
-
-import Test.Hspec
-import PostgresWebsockets
-import PostgresWebsockets.Config
-
 import Control.Lens
 import Data.Aeson.Lens
-
+import Network.Socket (withSocketsDo)
 import qualified Network.WebSockets as WS
-import           Network.Socket (withSocketsDo)
+import PostgresWebsockets
+import PostgresWebsockets.Config
+import Protolude
+import Test.Hspec
 
 testServerConfig :: AppConfig
-testServerConfig = AppConfig
-                    { configDatabase = "postgres://postgres:roottoor@localhost:5432/postgres_ws_test"
-                    , configPath = Nothing
-                    , configHost = "*"
-                    , configPort = 8080
-                    , configListenChannel = "postgres-websockets-test-channel"
-                    , configJwtSecret = "reallyreallyreallyreallyverysafe"
-                    , configMetaChannel = Nothing
-                    , configJwtSecretIsBase64 = False
-                    , configPool = 10
-                    , configRetries = 5
-                    , configReconnectInterval  = 0
-                    }
+testServerConfig =
+  AppConfig
+    { configDatabase = "postgres://postgres:roottoor@localhost:5432/postgres_ws_test",
+      configPath = Nothing,
+      configHost = "*",
+      configPort = 8080,
+      configListenChannel = "postgres-websockets-test-channel",
+      configJwtSecret = "reallyreallyreallyreallyverysafe",
+      configMetaChannel = Nothing,
+      configJwtSecretIsBase64 = False,
+      configPool = 10,
+      configRetries = 5,
+      configReconnectInterval = Nothing
+    }
 
 startTestServer :: IO ThreadId
 startTestServer = do
-    threadId <- forkIO $ serve testServerConfig
-    threadDelay 500000
-    pure threadId
+  threadId <- forkIO $ serve testServerConfig
+  threadDelay 500000
+  pure threadId
 
 withServer :: IO () -> IO ()
 withServer action =
-  bracket startTestServer
-          (\tid -> killThread tid >> threadDelay 500000)
-          (const action)
+  bracket
+    startTestServer
+    (\tid -> killThread tid >> threadDelay 500000)
+    (const action)
 
 sendWsData :: Text -> Text -> IO ()
 sendWsData uri msg =
-    withSocketsDo $
-        WS.runClient
-            "127.0.0.1"
-            (configPort testServerConfig)
-            (toS uri)
-            (`WS.sendTextData` msg)
+  withSocketsDo $
+    WS.runClient
+      "127.0.0.1"
+      (configPort testServerConfig)
+      (toS uri)
+      (`WS.sendTextData` msg)
 
 testChannel :: Text
 testChannel = "/test/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtb2RlIjoicncifQ.auy9z4-pqoVEAay9oMi1FuG7ux_C_9RQCH8-wZgej18"
@@ -59,62 +58,64 @@ testAndSecondaryChannel = "/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtb2RlIjoicnc
 
 waitForWsData :: Text -> IO (MVar ByteString)
 waitForWsData uri = do
-    msg <- newEmptyMVar
-    void $ forkIO $
-        withSocketsDo $
-            WS.runClient
-                "127.0.0.1"
-                (configPort testServerConfig)
-                (toS uri)
-                (\c -> do
-                    m <- WS.receiveData c
-                    putMVar msg m
-                )
-    threadDelay 10000
-    pure msg
+  msg <- newEmptyMVar
+  void $
+    forkIO $
+      withSocketsDo $
+        WS.runClient
+          "127.0.0.1"
+          (configPort testServerConfig)
+          (toS uri)
+          ( \c -> do
+              m <- WS.receiveData c
+              putMVar msg m
+          )
+  threadDelay 10000
+  pure msg
 
 waitForMultipleWsData :: Int -> Text -> IO (MVar [ByteString])
 waitForMultipleWsData messageCount uri = do
-    msg <- newEmptyMVar
-    void $ forkIO $
-        withSocketsDo $
-            WS.runClient
-                "127.0.0.1"
-                (configPort testServerConfig)
-                (toS uri)
-                (\c -> do
-                    m <- replicateM messageCount (WS.receiveData c)
-                    putMVar msg m
-                )
-    threadDelay 1000
-    pure msg
+  msg <- newEmptyMVar
+  void $
+    forkIO $
+      withSocketsDo $
+        WS.runClient
+          "127.0.0.1"
+          (configPort testServerConfig)
+          (toS uri)
+          ( \c -> do
+              m <- replicateM messageCount (WS.receiveData c)
+              putMVar msg m
+          )
+  threadDelay 1000
+  pure msg
 
 spec :: Spec
 spec = around_ withServer $
-            describe "serve" $ do
-                it "should be able to send messages to test server" $
-                    sendWsData testChannel "test data"
-                it "should be able to receive messages from test server" $ do
-                    msg <- waitForWsData testChannel
-                    sendWsData testChannel "test data"
-                    msgJson <- takeMVar msg
-                    (msgJson ^? key "payload" . _String) `shouldBe` Just "test data"
-                it "should be able to send messages to multiple channels in one shot" $ do
-                    msg <- waitForWsData testChannel
-                    secondaryMsg <- waitForWsData secondaryChannel
-                    sendWsData testAndSecondaryChannel "test data"
-                    msgJson <- takeMVar msg
-                    secondaryMsgJson <- takeMVar secondaryMsg
+  describe "serve" $ do
+    it "should be able to send messages to test server" $
+      sendWsData testChannel "test data"
+    it "should be able to receive messages from test server" $ do
+      msg <- waitForWsData testChannel
+      sendWsData testChannel "test data"
+      msgJson <- takeMVar msg
+      (msgJson ^? key "payload" . _String) `shouldBe` Just "test data"
+    it "should be able to send messages to multiple channels in one shot" $ do
+      msg <- waitForWsData testChannel
+      secondaryMsg <- waitForWsData secondaryChannel
+      sendWsData testAndSecondaryChannel "test data"
+      msgJson <- takeMVar msg
+      secondaryMsgJson <- takeMVar secondaryMsg
 
-                    (msgJson ^? key "payload" . _String) `shouldBe` Just "test data"
-                    (msgJson ^? key "channel" . _String) `shouldBe` Just "test"
-                    (secondaryMsgJson ^? key "payload" . _String) `shouldBe` Just "test data"
-                    (secondaryMsgJson ^? key "channel" . _String) `shouldBe` Just "secondary"
-                it "should be able to receive from multiple channels in one shot" $ do
-                    msgs <- waitForMultipleWsData 2 testAndSecondaryChannel
-                    sendWsData testAndSecondaryChannel "test data"
-                    msgsJson <- takeMVar msgs
+      (msgJson ^? key "payload" . _String) `shouldBe` Just "test data"
+      (msgJson ^? key "channel" . _String) `shouldBe` Just "test"
+      (secondaryMsgJson ^? key "payload" . _String) `shouldBe` Just "test data"
+      (secondaryMsgJson ^? key "channel" . _String) `shouldBe` Just "secondary"
+    it "should be able to receive from multiple channels in one shot" $ do
+      msgs <- waitForMultipleWsData 2 testAndSecondaryChannel
+      sendWsData testAndSecondaryChannel "test data"
+      msgsJson <- takeMVar msgs
 
-                    forM_
-                        msgsJson
-                        (\msgJson -> (msgJson ^? key "payload" . _String) `shouldBe` Just "test data")
+      forM_
+        msgsJson
+        (\msgJson -> (msgJson ^? key "payload" . _String) `shouldBe` Just "test data")


### PR DESCRIPTION
For more information on what this feature was designed to address check the issue #71 

## Goal

The user should be able to configure a supervisor thread for the listener connecion. When a listener connection is not detected by the supervisor it will open a new listener connection and reconnect the multiplexer.

## Configuration

We can use a variable such as `PGWS_CHECK_LISTENER_INTERVAL` where the user can configure a number of milliseconds between checks, and keep the current system behaviour by setting it to `0`. The default configuration would be `0` so the feature is backwards compatible with the current behaviour.

The time configured is roughly the maximum amount of time where messages could be lost due to the lack of listener.

## Implementation details

We will have to ensure that the producer thread for the `Multiplexer` is dead to avoid leaving any dangling resource. It seems that the supervisor and the producer termination behaviour are orthogonal but to avoid additional complexity the new setting will bypass the existing `shutdown the whole server` and just re-spawn the producer. 

In order to cancel the old thread we need to call the supervisor where the thread id of the open producer is available. Also, using the same `openProducer` function might simplify the code. One way to achieve both things is to keep both the `openProducer` function and the producer `threadId` in the `Multiplexer` and have another function such as `superviseMultiplexer :: Multiplexer -> IO ()` which would take a multiplexer and launch the supervisor. We could also bake the supervisor inside either `newHasqlBroadcasterForChannel` or `newMultiplexer` but those functions are complex enough as they are.

TODO:
- [x] Write a good description here of how the new feature is supposed to behave
- [x] Use that info to adjust the README so we have a clear target