### PR TITLE
Relax dependencies

### DIFF
--- a/postgres-websockets.cabal
+++ b/postgres-websockets.cabal
@@ -37,18 +37,18 @@ library
   build-depends:       base >= 4.7 && < 5
                      , aeson >= 2.0 && < 2.3
                      , alarmclock >= 0.7.0.2 && < 0.8
-                     , auto-update >= 0.1.6 && < 0.2
+                     , auto-update >= 0.1.6 && < 0.3
                      , base64-bytestring >= 1.0.0.3 && < 1.3
-                     , bytestring >= 0.11.5 && < 0.12
+                     , bytestring >= 0.11.5 && < 0.13
                      , either >= 5.0.1.1 && < 5.1
-                     , envparse >= 0.5.0 && < 0.6
-                     , hasql ^>= 1.7
+                     , envparse >= 0.5.0 && < 0.7
+                     , hasql >= 1.7 && < 1.9
                      , hasql-notifications >= 0.2.3.0 && < 0.3
                      , hasql-pool ^>= 1.2
                      , http-types >= 0.12.3 && < 0.13
                      , jose >= 0.11 && < 0.12
-                     , lens >= 5.2.3 && < 5.3
-                     , postgresql-libpq >= 0.10.0 && < 0.11
+                     , lens >= 5.2.3 && < 5.4
+                     , postgresql-libpq >= 0.10.0 && < 0.12
                      , protolude >= 0.2.3 && < 0.4
                      , retry >= 0.8.1.0 && < 0.10
                      , stm >= 2.5.0.0 && < 2.6
@@ -62,7 +62,7 @@ library
                      , wai-websockets >= 3.0 && < 4
                      , warp >= 3.2 && < 4
                      , warp-tls >= 3.2 && < 4
-                     , websockets >= 0.9 && < 0.13
+                     , websockets >= 0.9 && < 0.14
 
   default-language:    Haskell2010
 
@@ -93,7 +93,7 @@ test-suite postgres-websockets-test
                      , postgres-websockets
                      , hspec >= 2.7.1 && < 2.12
                      , aeson >= 2.0 && < 2.3
-                     , hasql ^>= 1.7
+                     , hasql >= 1.7 && < 1.9
                      , hasql-pool ^>= 1.2
                      , hasql-notifications >= 0.2.3.0 && < 0.3
                      , http-types >= 0.9
@@ -101,9 +101,9 @@ test-suite postgres-websockets-test
                      , unordered-containers >= 0.2
                      , wai-extra >= 3.0.29 && < 3.2
                      , stm >= 2.5.0.0 && < 2.6
-                     , websockets >= 0.12.7.0 && < 0.13
-                     , network >= 2.8.0.1 && < 3.2
-                     , lens >= 4.17.1 && < 5.3
+                     , websockets >= 0.12.7.0 && < 0.14
+                     , network >= 2.8.0.1 && < 3.3
+                     , lens >= 4.17.1 && < 5.4
                      , lens-aeson >= 1.0.0 && < 1.3
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010


### PR DESCRIPTION
Currently, postgres-websockets is marked as broken in nixpkgs, because it doesn't build. I am trying to unbreak it.

With the latest master branch and based on https://github.com/NixOS/nixpkgs/pull/371032, I get the following failure:

```
       > Error: Setup: Encountered missing or private dependencies:
       > auto-update >=0.1.6 && <0.2,
       > bytestring >=0.11.5 && <0.12,
       > envparse >=0.5.0 && <0.6,
       > hasql >=1.7 && <1.8,
       > lens >=5.2.3 && <5.3,
       > network >=2.8.0.1 && <3.2,
       > postgresql-libpq >=0.10.0 && <0.11,
       > websockets >=0.12.7.0 && <0.13
```

All of them can be relaxed and the result builds and runs the tests fine.

I effectively tested this with:
- auto-update 0.2.6 (latest)
- bytestring 0.12.1.0 (GHC 9.8)
- envparse 0.6 (latest)
- hasql 1.8.1.4 (latest is 1.9.1.1)
- lens 5.3.3 (latest is 5.3.4)
- network 3.2.7.0 (latest)
- postgresql-libpq 0.11.0.0 (latest)
- websockets 0.13.0.0 (latest)

Do you think it would be possible to cut a new release with this and all the changes on the master branch? That would unbreak the package in nixpkgs :)