### PR TITLE
Prevent connection from closing when opening channels without write mode

### DIFF
--- a/src/PostgresWebsockets/Config.hs
+++ b/src/PostgresWebsockets/Config.hs
@@ -18,7 +18,7 @@ import APrelude
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base64 as B64
 import Data.String (IsString (..))
-import Data.Text (intercalate, pack, replace, strip, stripPrefix)
+import Data.Text (intercalate, replace, strip, stripPrefix)
 import Data.Version (versionBranch)
 import Env
 import Network.Wai.Handler.Warp

--- a/src/PostgresWebsockets/HasqlBroadcast.hs
+++ b/src/PostgresWebsockets/HasqlBroadcast.hs
@@ -21,8 +21,6 @@ import Data.Aeson (Value (..), decode)
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as JSON
 import Data.Either.Combinators (mapBoth)
-import Data.Function (id)
-import GHC.Show
 import Hasql.Connection
 import qualified Hasql.Decoders as HD
 import qualified Hasql.Encoders as HE

--- a/src/PostgresWebsockets/Middleware.hs
+++ b/src/PostgresWebsockets/Middleware.hs
@@ -111,8 +111,7 @@ wsApp Context {..} pendingConn =
         when (hasWrite mode) $
           notifySession conn sendNotification chs
 
-        waitForever <- newEmptyMVar
-        void $ takeMVar waitForever
+        void $ forever $ threadDelay maxBound
 
 -- Having both channel and claims as parameters seem redundant
 -- But it allows the function to ignore the claims structure and the source


### PR DESCRIPTION
It seems that without the notifySession being open in the middleware, the runtime detects the waiting on the MVar as an infinite wait. Which although true, it's useful to relay read messages and the connection will be closed by warp when the client disconnects.

Using a `threadDelay` to wait fixes the issue and should not have a big impact on resources.

This should fix [#105]