### PR TITLE
Add JWKS Support

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,5 @@
+packages: .
+
+-- ram is an incompatible fork of memory that breaks jose compilation
+-- https://github.com/frasertweedale/hs-jose/issues/138
+constraints: ram < 0

--- a/postgres-websockets.cabal
+++ b/postgres-websockets.cabal
@@ -48,7 +48,7 @@ library
                      , hasql-notifications >= 0.2.4.0 && < 0.3
                      , hasql-pool ^>= 1.3
                      , http-types >= 0.12.3 && < 0.13
-                     , jose >= 0.11 && < 0.12
+                     , jose >= 0.11 && < 0.13
                      , lens >= 5.2.3 && < 5.4
                      , mtl >=2.3.1 && <2.4
                      , async >=2.2.5 && <2.3

--- a/src/PostgresWebsockets/Claims.hs
+++ b/src/PostgresWebsockets/Claims.hs
@@ -35,7 +35,7 @@ validateClaims ::
   UTCTime ->
   IO (Either Text ConnectionInfo)
 validateClaims requestChannel secret jwtToken time = runExceptT $ do
-  cl <- liftIO $ jwtClaims time (parseJWK secret) jwtToken
+  cl <- liftIO $ jwtClaims time (parseSecret secret) jwtToken
   cl' <- case cl of
     JWTClaims c -> pure c
     JWTInvalid JWTExpired -> throwError "Token expired"
@@ -82,13 +82,13 @@ data JWTAttempt
 -- |
 --  Receives the JWT secret (from config) and a JWT and returns a map
 --  of JWT claims.
-jwtClaims :: UTCTime -> JWK -> LByteString -> IO JWTAttempt
+jwtClaims :: UTCTime -> JWKSet -> LByteString -> IO JWTAttempt
 jwtClaims _ _ "" = return $ JWTClaims JSON.empty
-jwtClaims time jwk' payload = do
+jwtClaims time jwks payload = do
   let config = defaultJWTValidationSettings (const True)
   eJwt <- runExceptT $ do
     jwt <- decodeCompact payload
-    verifyClaimsAt config jwk' time jwt
+    verifyClaimsAt config jwks time (jwt :: SignedJWT)
   return $ case eJwt of
     Left e -> JWTInvalid e
     Right jwt -> JWTClaims . claims2map $ jwt
@@ -114,6 +114,8 @@ hs256jwk key =
   where
     km = OctKeyMaterial (OctKeyParameters (JOSE.Types.Base64Octets key))
 
-parseJWK :: ByteString -> JWK
-parseJWK str =
-  fromMaybe (hs256jwk str) (JSON.decode (fromStrict str) :: Maybe JWK)
+parseSecret :: ByteString -> JWKSet
+parseSecret str =
+  case JSON.decode (fromStrict str) :: Maybe JWKSet of
+    Just jwks -> jwks
+    Nothing -> JWKSet [fromMaybe (hs256jwk str) (JSON.decode (fromStrict str) :: Maybe JWK)]

--- a/test/ClaimsSpec.hs
+++ b/test/ClaimsSpec.hs
@@ -11,6 +11,14 @@ import Prelude
 secret :: ByteString
 secret = "reallyreallyreallyreallyverysafe"
 
+-- Same secret as a single JWK object
+jwkSecret :: ByteString
+jwkSecret = "{\"kty\":\"oct\",\"k\":\"cmVhbGx5cmVhbGx5cmVhbGx5cmVhbGx5dmVyeXNhZmU\",\"alg\":\"HS256\"}"
+
+-- Same secret wrapped in a JWKS envelope
+jwksSecret :: ByteString
+jwksSecret = "{\"keys\":[{\"kty\":\"oct\",\"k\":\"cmVhbGx5cmVhbGx5cmVhbGx5cmVhbGx5dmVyeXNhZmU\",\"alg\":\"HS256\"}]}"
+
 spec :: Spec
 spec =
   describe "validate claims" $ do
@@ -73,3 +81,34 @@ spec =
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjaGFubmVscyI6WyJ0ZXN0IiwidGVzdDIiXX0.akC1PEYk2DEZtLP2XjC6qXOGZJejmPx49qv-VeEtQYQ"
         time
         `shouldReturn` Left "Missing mode"
+
+    it "should validate a token using a JWK secret" $ do
+      time <- getCurrentTime
+      validateClaims
+        (Just "test")
+        jwkSecret
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtb2RlIjoiciIsImNoYW5uZWwiOiJ0ZXN0In0.1d4s-at2kWj8OSabHZHTbNh1dENF7NWy_r0ED3Rwf58"
+        time
+        `shouldReturn` Right (["test"], "r", JSON.fromList [("mode", String "r"), ("channel", String "test")])
+
+    it "should validate a token using a JWKS secret" $ do
+      time <- getCurrentTime
+      validateClaims
+        (Just "test")
+        jwksSecret
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtb2RlIjoiciIsImNoYW5uZWwiOiJ0ZXN0In0.1d4s-at2kWj8OSabHZHTbNh1dENF7NWy_r0ED3Rwf58"
+        time
+        `shouldReturn` Right (["test"], "r", JSON.fromList [("mode", String "r"), ("channel", String "test")])
+
+    it "should reject a token with wrong key in JWKS" $ do
+      time <- getCurrentTime
+      result <-
+        validateClaims
+          (Just "test")
+          "{\"keys\":[{\"kty\":\"oct\",\"k\":\"d3JvbmdrZXl3cm9uZ2tleXdyb25na2V5d3Jvbmdr\",\"alg\":\"HS256\"}]}"
+          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtb2RlIjoiciIsImNoYW5uZWwiOiJ0ZXN0In0.1d4s-at2kWj8OSabHZHTbNh1dENF7NWy_r0ED3Rwf58"
+          time
+      result `shouldSatisfy` isLeft
+  where
+    isLeft (Left _) = True
+    isLeft _ = False


### PR DESCRIPTION
## Summary

_Disclaimer: I have no prior experience writing Haskell and most of this contribution is driven by AI._

Added support for JWKS (JWK Sets). JWK was already supported by the current version of postgres-websocket, although not very well documented. **It works by specifying `PGWS_JWT_SECRET=@/run/secrets/jwk.json`.** However this only supports single key right now. JWKS (multiple keys) is supported by the underlying `jose` library and this pull request extends its use in postgres-websocket. This change should make it compatible with PostgREST implementation which already supports JWKS with `PGRST_JWT_SECRET=@/run/secrets/jwks.json`.

It first tries to parse the secret as JWKS, then as single JWK object and then finally as HMAC fallback for backwards compatibility.

## Changes

1. **Claims.hs**:
   - `parseJWK` → `parseSecret`: Now handles JWKSet, single JWK, and plain string secrets with fallback logic
   - `jwtClaims` signature: Accepts `JWKSet` for verification (supports automatic key selection by `kid`)
   - Added type annotation `:: SignedJWT` for jose-0.12 compatibility

2. **postgres-websockets.cabal**: Bumped jose from `< 0.12` to `< 0.13`

3. **cabal.project**: New configuration file with `constraints: ram < 0` (workaround for [jose#138](https://github.com/frasertweedale/hs-jose/issues/138))

4. **ClaimsSpec.hs**: 3 new tests
   - Token validation with JWK secret
   - Token validation with JWKS secret
   - Rejection with wrong key in JWKS

## Build & Test

```bash
# Prerequisites
brew install libpq ghcup
ghcup set ghc 9.6.7

# Build
cd postgres-websockets
PATH="/opt/homebrew/opt/libpq/bin:$PATH" cabal build --constraint='ram < 0'

# Test (Claims only, no DB required)
cabal test --constraint='ram < 0' -- --match "validate claims"
```

Result: **All 10 tests pass** (7 existing + 3 new JWKS tests)